### PR TITLE
removed useless section

### DIFF
--- a/src/base/linkfile.prx.in
+++ b/src/base/linkfile.prx.in
@@ -88,12 +88,12 @@ SECTIONS
   PROVIDE (_etext = .);
   PROVIDE (etext = .);
   /* PSP library entry table and library stub table. */
-  .lib.ent.top    : { *(.lib.ent.top) }
+  PROVIDE (__lib_ent_top = .);
   .lib.ent        : { *(.lib.ent) }
-  .lib.ent.btm    : { *(.lib.ent.btm) }
-  .lib.stub.top   : { *(.lib.stub.top) }
+  PROVIDE (__lib_ent_bottom = .);
+  PROVIDE (__lib_stub_top = .);
   .lib.stub       : { *(.lib.stub) }
-  .lib.stub.btm   : { *(.lib.stub.btm) }
+  PROVIDE (__lib_stub_bottom = .);
   /* PSP read-only data for module info, NIDs, and Vstubs.  The
      .rodata.sceModuleInfo section must appear before the .rodata section
      otherwise it would get absorbed into .rodata and the PSP bootloader

--- a/src/user/pspmoduleinfo.h
+++ b/src/user/pspmoduleinfo.h
@@ -48,27 +48,6 @@ enum PspModuleInfoAttr
 
 /* Declare a module.  This must be specified in the source of a library or executable. */
 #define PSP_MODULE_INFO(name, attributes, major_version, minor_version) \
-	__asm__ (                                                       \
-	"    .set push\n"                                               \
-	"    .section .lib.ent.top, \"a\", @progbits\n"                 \
-	"    .align 2\n"                                                \
-	"    .word 0\n"                                                 \
-	"__lib_ent_top:\n"                                              \
-	"    .section .lib.ent.btm, \"a\", @progbits\n"                 \
-	"    .align 2\n"                                                \
-	"__lib_ent_bottom:\n"                                           \
-	"    .word 0\n"                                                 \
-	"    .section .lib.stub.top, \"a\", @progbits\n"                \
-	"    .align 2\n"                                                \
-	"    .word 0\n"                                                 \
-	"__lib_stub_top:\n"                                             \
-	"    .section .lib.stub.btm, \"a\", @progbits\n"                \
-	"    .align 2\n"                                                \
-	"__lib_stub_bottom:\n"                                          \
-	"    .word 0\n"                                                 \
-	"    .set pop\n"                                                \
-	"    .text\n"													\
-	);                                                              \
 	extern char __lib_ent_top[], __lib_ent_bottom[];                \
 	extern char __lib_stub_top[], __lib_stub_bottom[];              \
 	extern SceModuleInfo module_info                                \
@@ -81,27 +60,6 @@ enum PspModuleInfoAttr
 #else
 /* Declare a module.  This must be specified in the source of a library or executable. */
 #define PSP_MODULE_INFO(name, attributes, major_version, minor_version) \
-	__asm__ (                                                       \
-	"    .set push\n"                                               \
-	"    .section .lib.ent.top, \"a\", @progbits\n"                 \
-	"    .align 2\n"                                                \
-	"    .word 0\n"                                                 \
-	"__lib_ent_top:\n"                                              \
-	"    .section .lib.ent.btm, \"a\", @progbits\n"                 \
-	"    .align 2\n"                                                \
-	"__lib_ent_bottom:\n"                                           \
-	"    .word 0\n"                                                 \
-	"    .section .lib.stub.top, \"a\", @progbits\n"                \
-	"    .align 2\n"                                                \
-	"    .word 0\n"                                                 \
-	"__lib_stub_top:\n"                                             \
-	"    .section .lib.stub.btm, \"a\", @progbits\n"                \
-	"    .align 2\n"                                                \
-	"__lib_stub_bottom:\n"                                          \
-	"    .word 0\n"                                                 \
-	"    .set pop\n"                                                \
-	"    .text\n"													\
-	);                                                              \
 	extern char __lib_ent_top[], __lib_ent_bottom[];                \
 	extern char __lib_stub_top[], __lib_stub_bottom[];              \
 	SceModuleInfo module_info                                       \


### PR DESCRIPTION
PSP_MODULE_INFO macro use asm() to create 4 section that will wrap both `.lib.ent` and `.lib.stub` and then declare a global pointer to those section.
This can be done easier using PROVIDE() in the linkfile.prx.in file.

Compilation succeed and generated PRX work perfectly (tested on 5.00M33 through PSPlink).
