### PR TITLE
Race condition during make install-data

### DIFF
--- a/src/mpeg/Makefile.am
+++ b/src/mpeg/Makefile.am
@@ -25,9 +25,6 @@ libpspmpeginclude_HEADERS = pspmpeg.h
 libpspmpegbaseincludedir = @PSPSDK_INCLUDEDIR@
 libpspmpegbaseinclude_HEADERS = pspmpegbase.h
 
-libpspmpegbase_driverincludedir = @PSPSDK_INCLUDEDIR@
-libpspmpegbase_driverinclude_HEADERS = pspmpegbase.h
-
 libpspjpegincludedir = @PSPSDK_INCLUDEDIR@
 libpspjpeginclude_HEADERS = pspjpeg.h
 


### PR DESCRIPTION
*pspmpegbase.h* header is included twice: once as *libpspmpegbaseinclude_HEADERS* and once as *libpspmpegbase_driverinclude_HEADERS*, in `src/mpeg/Makefile`

When Travis_CI runs `make -j 32 install-data`, race condition occurs on that file, and installation fails

Is it really needed to have it defined such way ?