### PR TITLE
Added functions to identify PSP Model

### DIFF
--- a/src/kernel/pspsyscon.h
+++ b/src/kernel/pspsyscon.h
@@ -65,6 +65,18 @@ int sceSysconSetHPConnectCallback( void (*)(int), int unk0 );
 
 int sceSysconSetHRPowerCallback( void (*)(int), int unk0 );
 
+/**
+ * Get the PSP's Pommel version
+ * @param version - A pointer to an int to receive the Pommel version into
+ */
+int sceSysconGetPommelVersion( int* version );
+
+/**
+ * Get the PSP's Baryon version
+ * @param version - A pointer to an int to receive the Baryon version into
+ */
+int sceSysconGetBaryonVersion( int* version );
+
 /*@}*/
 
 #ifdef __cplusplus

--- a/src/kernel/pspsysreg.h
+++ b/src/kernel/pspsysreg.h
@@ -69,6 +69,12 @@ int sceSysregMeBusClockEnable(void);
   */
 int sceSysregMeBusClockDisable(void);
 
+/**
+ * Get the PSP's Tachyon version.
+ * @param version - A pointer to an int to receive the Tachyon version into
+ */
+int sceSysconGetTachyonVersion( int* version );
+
 /*@}*/
 
 #ifdef __cplusplus

--- a/src/kernel/sceSyscon_driver.S
+++ b/src/kernel/sceSyscon_driver.S
@@ -129,7 +129,7 @@
 	IMPORT_FUNC	"sceSyscon_driver",0xE6B74CB9,sceSysconNop
 #endif
 #ifdef F_sceSyscon_driver_0042
-	IMPORT_FUNC	"sceSyscon_driver",0x7EC5A957,sceSyscon_driver_7EC5A957
+	IMPORT_FUNC	"sceSyscon_driver",0x7EC5A957,sceSysconGetBaryonVersion
 #endif
 #ifdef F_sceSyscon_driver_0043
 	IMPORT_FUNC	"sceSyscon_driver",0x7BCC5EAE,sceSyscon_driver_7BCC5EAE
@@ -192,7 +192,7 @@
 	IMPORT_FUNC	"sceSyscon_driver",0x91E183CB,sceSysconPowerSuspend
 #endif
 #ifdef F_sceSyscon_driver_0063
-	IMPORT_FUNC	"sceSyscon_driver",0xE7E87741,sceSyscon_driver_E7E87741
+	IMPORT_FUNC	"sceSyscon_driver",0xE7E87741,sceSysconGetPommelVersion
 #endif
 #ifdef F_sceSyscon_driver_0064
 	IMPORT_FUNC	"sceSyscon_driver",0xFB148FB6,sceSyscon_driver_FB148FB6

--- a/src/kernel/sceSysreg_driver.S
+++ b/src/kernel/sceSysreg_driver.S
@@ -21,7 +21,7 @@
 	IMPORT_FUNC	"sceSysreg_driver",0x844AF6BD,sceSysreg_driver_844AF6BD
 #endif
 #ifdef F_sceSysreg_driver_0006
-	IMPORT_FUNC	"sceSysreg_driver",0xE2A5D1EE,sceSysreg_driver_E2A5D1EE
+	IMPORT_FUNC	"sceSysreg_driver",0xE2A5D1EE,sceSysregGetTachyonVersion
 #endif
 #ifdef F_sceSysreg_driver_0007
 	IMPORT_FUNC	"sceSysreg_driver",0x4F46EEDE,sceSysreg_driver_4F46EEDE


### PR DESCRIPTION
This renames and defines the functions needed to identify a PSP Model, which is needed to fix the GDB bug.
