### PR TITLE
Remove the `-mno-crt0` flag from build_prx.mak

### DIFF
--- a/src/base/build_prx.mak
+++ b/src/base/build_prx.mak
@@ -29,7 +29,7 @@ CFLAGS   := $(addprefix -I,$(INCDIR)) $(CFLAGS)
 CXXFLAGS := $(CFLAGS) $(CXXFLAGS)
 ASFLAGS  := $(CFLAGS) $(ASFLAGS)
 
-LDFLAGS  := $(addprefix -L,$(LIBDIR)) -Wl,-q,-T$(PSPSDK)/lib/linkfile.prx -mno-crt0 -nostartfiles $(LDFLAGS)
+LDFLAGS  := $(addprefix -L,$(LIBDIR)) -Wl,-q,-T$(PSPSDK)/lib/linkfile.prx -nostartfiles $(LDFLAGS)
 
 ifeq ($(PSP_FW_VERSION),)
 PSP_FW_VERSION=150


### PR DESCRIPTION
`-mno-crt0` does not exist in current versions of psp-gcc installed by the toolchain, and `-nostartfiles` appears to be equivalent.

fixes #24