### PR TITLE
Remove another obscure useless relocation type made by the new (psp-)gcc

### DIFF
--- a/tools/psp-prxgen.c
+++ b/tools/psp-prxgen.c
@@ -419,7 +419,7 @@ int remove_weak_relocs(struct ElfSection *pReloc, struct ElfSection *pSymbol, st
 			}
 
 			/* Remove PC16 relocations (unsupported by PSP, and useless) */
-			if(LH(pSymData[iSymbol].st_shndx) == 0 || ELF32_R_TYPE(LW(pInRel->r_info)) == R_MIPS_PC16)
+			if(LH(pSymData[iSymbol].st_shndx) == 0 || ELF32_R_TYPE(LW(pInRel->r_info)) == R_MIPS_PC16 || ELF32_R_TYPE(LW(pInRel->r_info)) == R_MIPS_GPREL16)
 			{
 				if(g_verbose)
 				{


### PR DESCRIPTION
Fixes running modules on OFW (after being encrypted with PrxEncrypter ofc)