### PR TITLE
Fix GetTachyonVersion prefix

### DIFF
--- a/src/kernel/pspsysreg.h
+++ b/src/kernel/pspsysreg.h
@@ -72,7 +72,7 @@ int sceSysregMeBusClockDisable(void);
  * Get the PSP's Tachyon version.
  * @param version - A pointer to an int to receive the Tachyon version into
  */
-int sceSysconGetTachyonVersion( int* version );
+int sceSysregGetTachyonVersion( int* version );
 
 /**@}*/
 


### PR DESCRIPTION
pspsysreg.h contains `sceSysconGetTachyonVersion` instead of `sceSysregGetTachyonVersion` as named in the exports