### PR TITLE
Fix gettimeofday & other small improvements

### DIFF
--- a/src/libcglue/Makefile.am
+++ b/src/libcglue/Makefile.am
@@ -11,7 +11,6 @@ CPPFLAGS = -I$(top_srcdir)/src/base \
 	-I$(top_srcdir)/src/sdk \
 	-I$(top_srcdir)/src/kernel \
 	-I$(top_srcdir)/src/net \
-	-I$(top_srcdir)/src/user \
 	-I$(top_srcdir)/src/rtc \
 	-I$(top_srcdir)/src/user \
 	-I$(top_srcdir)/src/utility
@@ -27,7 +26,7 @@ FDMAN_OBJS = __descriptor_data_pool.o __descriptormap.o __fdman_init.o __fdman_g
 
 GLUE_OBJS = __fill_stat.o __psp_heap_blockid.o __psp_free_heap.o _fork.o _wait.o _open.o _close.o _read.o _write.o _fstat.o \
 	_stat.o lstat.o access.o _fcntl.o  _lseek.o chdir.o mkdir.o rmdir.o getdents.o _seekdir.o _link.o _unlink.o \
-	_rename.o _getpid.o _kill.o _sbrk.o _gettimeofday.o _times.o _internal_malloc_lock.o _internal_malloc_unlock.o \
+	_rename.o _getpid.o _kill.o _sbrk.o _gettimeofday.o _times.o ftime.o _internal_malloc_lock.o _internal_malloc_unlock.o \
 	_isatty.o symlink.o truncate.o chmod.o fchmod.o fchmodat.o pathconf.o readlink.o utime.o fchown.o getentropy.o
 
 

--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -703,7 +703,18 @@ void * _sbrk(ptrdiff_t incr)
 #ifdef F__gettimeofday
 int _gettimeofday(struct timeval *tp, struct timezone *tzp)
 {
-	return __set_errno(sceKernelLibcGettimeofday(tp, tzp));
+	int ret;
+	struct SceKernelTimeval pspTimeval;
+
+	ret = __set_errno(sceKernelLibcGettimeofday(&pspTimeval, tzp));
+	if (ret < 0)
+		return ret;
+
+	/* Return the actual time since epoch */
+	tp->tv_sec = pspTimeval.tv_sec;
+	tp->tv_usec = pspTimeval.tv_usec;
+
+	return 0;
 }
 #endif
 

--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -24,6 +24,7 @@
 #include <unistd.h>
 
 #include <sys/time.h>
+#include <sys/timeb.h>
 #include <sys/times.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -731,6 +732,23 @@ clock_t _times(struct tms *buffer)
 	}
 
 	return clk;
+}
+#endif
+
+#ifdef F_ftime
+int ftime(struct timeb *tb)
+{
+  struct timeval tv;
+  struct timezone tz;
+
+  gettimeofday(&tv, &tz);
+
+  tb->time = tv.tv_sec;
+  tb->millitm = tv.tv_usec / 1000;
+  tb->timezone = tz.tz_minuteswest;
+  tb->dstflag = tz.tz_dsttime;
+
+  return 0;
 }
 #endif
 

--- a/src/libcglue/select.c
+++ b/src/libcglue/select.c
@@ -31,7 +31,7 @@ static int __poll_select(int n, fd_set *readfds, fd_set *writefds, fd_set *excep
 	fd_set ready_readfds, ready_writefds, ready_exceptfds;
 	fd_set scereadfds, scewritefds;
 	SceKernelMppInfo info;
-	struct timeval scetv;
+	struct SceNetInetTimeval scetv;
 
 	FD_ZERO(&ready_readfds);
 	FD_ZERO(&ready_writefds);

--- a/src/libcglue/sleep.c
+++ b/src/libcglue/sleep.c
@@ -9,23 +9,26 @@
  *
  */
 
-#include <pspthreadman.h>
-
-#include <errno.h>
+#include <stdio.h>
 #include <time.h>
 #include <unistd.h>
+#include <errno.h>
+
+#include <pspthreadman.h>
 
 #ifdef F_nanosleep
 /* note: we don't use rem as we have no signals */
 int nanosleep(const struct timespec *req, struct timespec *rem)
 {
-	sceKernelDelayThreadCB( 1000000 * req->tv_sec + (req->tv_nsec / 1000) );
+	int res = 0;
+    uint32_t usec = 1000000 * req->tv_sec + (req->tv_nsec / 1000);
+    res = __set_errno(sceKernelDelayThread(usec));
 	
     if( rem != NULL ) {
         rem->tv_sec = 0;
         rem->tv_nsec = 0;
     }
 
-    return 0;
+    return res;
 }
 #endif

--- a/src/net/pspnet_inet.h
+++ b/src/net/pspnet_inet.h
@@ -18,8 +18,17 @@
 extern "C" {
 #endif
 
+/** 
+ *  This struct is needed because tv_sec size is different from what newlib expect
+ *  Newlib expects 64bits for seconds and PSP expects 32bits
+ */
+struct SceNetInetTimeval {
+    uint32_t tv_sec;
+    uint32_t tv_usec;
+};
+
 int sceNetInetInit(void);
-int sceNetInetSelect(int n, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout);
+int sceNetInetSelect(int n, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct SceNetInetTimeval *timeout);
 int sceNetInetTerm(void);
 int sceNetInetGetErrno(void);
 

--- a/src/samples/Makefile.samples
+++ b/src/samples/Makefile.samples
@@ -83,6 +83,6 @@ SAMPLES = \
 
 all:
 	for sample in $(SAMPLES) ; do \
-		$(MAKE) -f Makefile.sample -C $$sample clean all || break; \
+		$(MAKE) -f Makefile.sample -C $$sample clean all || { exit 1; } \
 	done
 

--- a/src/user/psputils.h
+++ b/src/user/psputils.h
@@ -30,6 +30,15 @@ extern "C" {
 
 #include <sys/time.h>
 
+/** 
+ *  This struct is needed because tv_sec size is different from what newlib expect
+ * Newlib expects 64bits for seconds and PSP expects 32bits
+ */
+typedef struct SceKernelTimeval {
+	uint32_t tv_sec;
+	uint32_t tv_usec;
+} SceKernelTimeval;
+
 /**
   * Get the time in seconds since the epoc (1st Jan 1970)
   *
@@ -44,7 +53,7 @@ clock_t sceKernelLibcClock(void);
 /**
   * Get the current time of time and time zone information
   */
-int sceKernelLibcGettimeofday(struct timeval *tp, struct timezone *tzp);
+int sceKernelLibcGettimeofday(struct SceKernelTimeval *tp, struct timezone *tzp);
 
 /**
   * Write back the data cache to memory


### PR DESCRIPTION
# Description

This PR fixes a wrong implementation of `int _gettimeofday(struct timeval *tp, struct timezone *tzp)` glue function.

`Newlib` expects to have in the `struct timeval` the `tv_sec` parameter as 64bits item, however `PSP OS`, when calling `sceKernelLibcGettimeofday`, it expects `tv_sec` to be 32bits. Similar issue happens with `select` function for `inet`.

Other minor improvements have been done.