### PR TITLE
Remove specific condition for heap and PRX files

### DIFF
--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -41,13 +41,11 @@
 
 #include "fdman.h"
 
-#define DEFAULT_PRX_HEAP_SIZE_KB 64
 #define DEFAULT_HEAP_THRESHOLD_SIZE_KB 512
 
 /* If defined it specifies the desired size of the heap, in KB. */
 extern unsigned int sce_newlib_heap_kb_size __attribute__((weak));
 extern unsigned int sce_newlib_heap_threshold_kb_size __attribute__((weak));
-extern int __pspsdk_is_prx __attribute__((weak));
 
 /* Functions from cwd.c */
 extern char __cwd[MAXNAMLEN + 1];
@@ -666,8 +664,6 @@ void * _sbrk(ptrdiff_t incr)
 
 		if (&sce_newlib_heap_kb_size != NULL) {
 			heap_size = TO_KB(sce_newlib_heap_kb_size);
-		} else if(&__pspsdk_is_prx != NULL) {
-			heap_size = TO_KB(DEFAULT_PRX_HEAP_SIZE_KB);
 		}
 
 		if ((int)heap_size < 0) {

--- a/src/startup/crt0_prx.c
+++ b/src/startup/crt0_prx.c
@@ -24,9 +24,6 @@
 #define DEFAULT_THREAD_STACK_KB_SIZE 256
 #define DEFAULT_MAIN_THREAD_NAME "user_main"
 
-/* Define us as a prx */
-int __pspsdk_is_prx = 1;
-
 /* If these variables are defined by the program, then they override the
    defaults given above. */
 extern int sce_newlib_nocreate_thread_in_start __attribute__((weak));


### PR DESCRIPTION
# Description

There was a specific condition in the `PRX` files for having by default `64 KB of HEAP`. I created this condition because I thought was mandatory, however, after some testing, I faced that it wasn't needed.

The test was done together with @davidgf

Thanks