### PR TITLE
Move inline stubs to a separated asm file

### DIFF
--- a/src/sdk/Makefile.am
+++ b/src/sdk/Makefile.am
@@ -31,7 +31,7 @@ INETHELPER_OBJS = pspSdkLoadInetModules.o pspSdkInetInit.o pspSdkInetTerm.o
 MULT_SRCS = modulemgr_patches.c inethelper.c
 MULT_OBJS = $(MODULEMGR_PATCHES_OBJS) $(INETHELPER_OBJS)
 
-libpspsdk_a_SOURCES = query_mod.c loadmodule.c fixup.c threadutils.c interrupt.S k1set.S  fpu.S $(MULT_SRCS)
+libpspsdk_a_SOURCES = query_mod.c loadmodule.c fixup.c threadutils.c interrupt.S k1set.S modinfo.S fpu.S $(MULT_SRCS)
 libpspsdk_a_LIBADD  = $(MULT_OBJS)
 
 $(MODULEMGR_PATCHES_OBJS): modulemgr_patches.c

--- a/src/sdk/modinfo.S
+++ b/src/sdk/modinfo.S
@@ -1,0 +1,26 @@
+
+.global __lib_ent_top
+.global __lib_ent_bottom
+.global __lib_stub_top
+.global __lib_stub_bottom
+
+.set push
+.section .lib.ent.top, "a", @progbits
+.align 2
+.word 0
+__lib_ent_top:
+.section .lib.ent.btm, "a", @progbits
+.align 2
+__lib_ent_bottom:
+.word 0
+.section .lib.stub.top, "a", @progbits
+.align 2
+.word 0
+__lib_stub_top:
+.section .lib.stub.btm, "a", @progbits
+.align 2
+__lib_stub_bottom:
+.word 0
+.set pop
+.text
+

--- a/src/user/pspmoduleinfo.h
+++ b/src/user/pspmoduleinfo.h
@@ -47,27 +47,6 @@ enum PspModuleInfoAttr
 
 /* Declare a module.  This must be specified in the source of a library or executable. */
 #define PSP_MODULE_INFO(name, attributes, major_version, minor_version) \
-	__asm__ (                                                       \
-	"    .set push\n"                                               \
-	"    .section .lib.ent.top, \"a\", @progbits\n"                 \
-	"    .align 2\n"                                                \
-	"    .word 0\n"                                                 \
-	"__lib_ent_top:\n"                                              \
-	"    .section .lib.ent.btm, \"a\", @progbits\n"                 \
-	"    .align 2\n"                                                \
-	"__lib_ent_bottom:\n"                                           \
-	"    .word 0\n"                                                 \
-	"    .section .lib.stub.top, \"a\", @progbits\n"                \
-	"    .align 2\n"                                                \
-	"    .word 0\n"                                                 \
-	"__lib_stub_top:\n"                                             \
-	"    .section .lib.stub.btm, \"a\", @progbits\n"                \
-	"    .align 2\n"                                                \
-	"__lib_stub_bottom:\n"                                          \
-	"    .word 0\n"                                                 \
-	"    .set pop\n"                                                \
-	"    .text\n"													\
-	);                                                              \
 	extern char __lib_ent_top[], __lib_ent_bottom[];                \
 	extern char __lib_stub_top[], __lib_stub_bottom[];              \
 	extern SceModuleInfo module_info                                \
@@ -80,27 +59,6 @@ enum PspModuleInfoAttr
 #else
 /* Declare a module.  This must be specified in the source of a library or executable. */
 #define PSP_MODULE_INFO(name, attributes, major_version, minor_version) \
-	__asm__ (                                                       \
-	"    .set push\n"                                               \
-	"    .section .lib.ent.top, \"a\", @progbits\n"                 \
-	"    .align 2\n"                                                \
-	"    .word 0\n"                                                 \
-	"__lib_ent_top:\n"                                              \
-	"    .section .lib.ent.btm, \"a\", @progbits\n"                 \
-	"    .align 2\n"                                                \
-	"__lib_ent_bottom:\n"                                           \
-	"    .word 0\n"                                                 \
-	"    .section .lib.stub.top, \"a\", @progbits\n"                \
-	"    .align 2\n"                                                \
-	"    .word 0\n"                                                 \
-	"__lib_stub_top:\n"                                             \
-	"    .section .lib.stub.btm, \"a\", @progbits\n"                \
-	"    .align 2\n"                                                \
-	"__lib_stub_bottom:\n"                                          \
-	"    .word 0\n"                                                 \
-	"    .set pop\n"                                                \
-	"    .text\n"													\
-	);                                                              \
 	extern char __lib_ent_top[], __lib_ent_bottom[];                \
 	extern char __lib_stub_top[], __lib_stub_bottom[];              \
 	SceModuleInfo module_info                                       \


### PR DESCRIPTION
Defining asm labels in inline assembly is not a good idea, according to
GCC docs it can result in labels being deleted (optimized away) or even
duplicated (see https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html).

This affects LTO linking, since LTO removes the four symbols and results
in undefined references. Using an ASM file makes sure that symbols exist
with the correct attributes.