### PR TITLE
Add some more POSIX API calls

### DIFF
--- a/src/libcglue/Makefile.am
+++ b/src/libcglue/Makefile.am
@@ -28,7 +28,7 @@ GLUE_OBJS = __fill_stat.o __psp_heap_blockid.o __psp_free_heap.o _fork.o _wait.o
 	_stat.o lstat.o access.o _fcntl.o  _lseek.o chdir.o mkdir.o rmdir.o getdents.o _seekdir.o _link.o _unlink.o \
 	_rename.o _getpid.o _kill.o _sbrk.o _gettimeofday.o _times.o ftime.o _internal_malloc_lock.o _internal_malloc_unlock.o \
 	_isatty.o symlink.o truncate.o chmod.o fchmod.o fchmodat.o pathconf.o readlink.o utime.o fchown.o getentropy.o getpwuid.o \
-	getpwnam.o
+	getpwnam.o getuid.o geteuid.o
 
 
 INIT_OBJS = __libcglue_init.o __libcglue_deinit.o _exit.o abort.o exit.o

--- a/src/libcglue/Makefile.am
+++ b/src/libcglue/Makefile.am
@@ -27,7 +27,8 @@ FDMAN_OBJS = __descriptor_data_pool.o __descriptormap.o __fdman_init.o __fdman_g
 GLUE_OBJS = __fill_stat.o __psp_heap_blockid.o __psp_free_heap.o _fork.o _wait.o _open.o _close.o _read.o _write.o _fstat.o \
 	_stat.o lstat.o access.o _fcntl.o  _lseek.o chdir.o mkdir.o rmdir.o getdents.o _seekdir.o _link.o _unlink.o \
 	_rename.o _getpid.o _kill.o _sbrk.o _gettimeofday.o _times.o ftime.o _internal_malloc_lock.o _internal_malloc_unlock.o \
-	_isatty.o symlink.o truncate.o chmod.o fchmod.o fchmodat.o pathconf.o readlink.o utime.o fchown.o getentropy.o
+	_isatty.o symlink.o truncate.o chmod.o fchmod.o fchmodat.o pathconf.o readlink.o utime.o fchown.o getentropy.o getpwuid.o \
+	getpwnam.o
 
 
 INIT_OBJS = __libcglue_init.o __libcglue_deinit.o _exit.o abort.o exit.o

--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -22,6 +22,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <pwd.h>
 
 #include <sys/time.h>
 #include <sys/timeb.h>
@@ -927,3 +928,18 @@ int getentropy(void *buffer, size_t length) {
 	return 0;
 }
 #endif
+
+#ifdef F_getpwuid
+struct passwd *getpwuid(uid_t uid) {
+	/* There's no support for users */
+	return NULL;
+}
+#endif
+
+#ifdef F_getpwnam
+struct passwd *getpwnam(const char *name) {
+	/* There's no support for users */
+	return NULL;
+}
+#endif
+

--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -929,6 +929,20 @@ int getentropy(void *buffer, size_t length) {
 }
 #endif
 
+#ifdef F_getuid
+uid_t getuid(void) {
+	/* Not sure if returning root is a good idea */
+	return 0;
+}
+#endif
+
+#ifdef F_geteuid
+uid_t geteuid(void) {
+	/* Not sure if returning root is a good idea */
+	return 0;
+}
+#endif
+
 #ifdef F_getpwuid
 struct passwd *getpwuid(uid_t uid) {
 	/* There's no support for users */

--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -931,15 +931,13 @@ int getentropy(void *buffer, size_t length) {
 
 #ifdef F_getuid
 uid_t getuid(void) {
-	/* Not sure if returning root is a good idea */
-	return 0;
+	return 1000;
 }
 #endif
 
 #ifdef F_geteuid
 uid_t geteuid(void) {
-	/* Not sure if returning root is a good idea */
-	return 0;
+	return 1000;
 }
 #endif
 


### PR DESCRIPTION
This adds some stuff used by libconfuse, but potentially other programs that attempt to find the user's HOME dir by parsing the password structure.
No PSP homebrew should use these functions, but there are always some off-the-shelf libs that attempt to use this as a POSIX platform :)