### PR TITLE
Use psp-pkg-config for FindPkgConfig in CMake

### DIFF
--- a/src/base/pspdev.cmake
+++ b/src/base/pspdev.cmake
@@ -22,7 +22,7 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
-SET(PKG_CONFIG_EXECUTABLE "${PSPDEV}/bin/psp-pkg-config" CACHE PATH "psp-pkg-config executable")
+SET(PKG_CONFIG_EXECUTABLE "${PSPDEV}/bin/psp-pkg-config")
 
 ## Add Default PSPSDK Libraries according to build.mak and add stdc++ for C++ builds so this doesn't need to be done manually later
 include_directories(${PSPDEV}/psp/include ${PSPDEV}/psp/sdk/include)

--- a/src/base/pspdev.cmake
+++ b/src/base/pspdev.cmake
@@ -22,6 +22,8 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
+SET(PKG_CONFIG_EXECUTABLE "${PSPDEV}/bin/psp-pkg-config" CACHE PATH "psp-pkg-config executable")
+
 ## Add Default PSPSDK Libraries according to build.mak and add stdc++ for C++ builds so this doesn't need to be done manually later
 include_directories(${PSPDEV}/psp/include ${PSPDEV}/psp/sdk/include)
 link_directories( ${PSPDEV}/lib ${PSPDEV}/psp/lib ${PSPDEV}/psp/sdk/lib)


### PR DESCRIPTION
This make it so that when using the following code:

```
include(FindPkgConfig)
pkg_search_module(SDL2 REQUIRED sdl2)
```

The variables ``${SDL2_INCLUDE_DIRS}`` and ``${SDL2_LIBRARIES}`` are set to the expected values within CMake.