### PR TITLE
psputils.h: fix header inclusion for clock_t

### DIFF
--- a/src/user/psputils.h
+++ b/src/user/psputils.h
@@ -28,7 +28,7 @@ extern "C" {
 
 /**@{*/
 
-#include <sys/time.h>
+#include <time.h>
 
 /** 
  *  This struct is needed because tv_sec size is different from what newlib expect


### PR DESCRIPTION
clock_t is defined in <time.h>, but not <sys/time.h> in newlib 4.1.0.

this fixes a compile error in files including this header:

In file included from psp-elf/bin/../psp/sdk/include/pspuser.h:25:0,
                 from psp-elf/bin/../psp/sdk/include/pspkernel.h:17,
                 from ./include/driver/me.h:5,
                 from src/me.c:1:
psp-elf/bin/../psp/sdk/include/psputils.h:51:1: error: unknown type name 'clock_t'
make[1]: *** [src/me.o] Error 1

encountered while trying to compile MElib.