### PR TITLE
Adding `clock_getres`, `clock_gettime` and `clock_settime` to `libcglue`

### DIFF
--- a/src/libcglue/Makefile.am
+++ b/src/libcglue/Makefile.am
@@ -26,9 +26,9 @@ FDMAN_OBJS = __descriptor_data_pool.o __descriptormap.o __fdman_init.o __fdman_g
 
 GLUE_OBJS = __dummy_passwd.o __fill_stat.o __psp_heap_blockid.o __psp_free_heap.o _fork.o _wait.o _open.o _close.o _read.o \
 	_write.o _fstat.o _stat.o lstat.o access.o _fcntl.o  _lseek.o chdir.o mkdir.o rmdir.o getdents.o _seekdir.o _link.o _unlink.o \
-	_rename.o _getpid.o _kill.o _sbrk.o _gettimeofday.o _times.o ftime.o _internal_malloc_lock.o _internal_malloc_unlock.o \
-	_isatty.o symlink.o truncate.o chmod.o fchmod.o fchmodat.o pathconf.o readlink.o utime.o fchown.o getentropy.o getpwuid.o \
-	fsync.o getpwnam.o getuid.o geteuid.o
+	_rename.o _getpid.o _kill.o _sbrk.o _gettimeofday.o _times.o ftime.o clock_getres.o clock_gettime.o clock_settime.o \
+	_internal_malloc_lock.o _internal_malloc_unlock.o _isatty.o symlink.o truncate.o chmod.o fchmod.o fchmodat.o pathconf.o \
+	readlink.o utime.o fchown.o getentropy.o getpwuid.o fsync.o getpwnam.o getuid.o geteuid.o
 
 
 INIT_OBJS = __libpthreadglue_init.o __libcglue_init.o __libcglue_deinit.o _exit.o abort.o exit.o

--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -758,6 +758,49 @@ int ftime(struct timeb *tb)
 }
 #endif
 
+#ifdef F_clock_getres
+int clock_getres(clockid_t clk_id, struct timespec *res)
+{
+	int ret;
+	struct SceKernelTimeval pspTimeval;
+
+	ret = __set_errno(sceKernelLibcGettimeofday(&pspTimeval, NULL));
+	if (ret < 0)
+		return ret;
+
+	/* Return the actual time since epoch */
+	res->tv_sec = pspTimeval.tv_sec;
+	res->tv_nsec = 1000 * pspTimeval.tv_usec;
+
+	return 0;
+}
+#endif
+
+#ifdef F_clock_gettime
+int clock_gettime(clockid_t clk_id, struct timespec *tp)
+{
+	int ret;
+	struct SceKernelTimeval pspTimeval;
+
+	ret = __set_errno(sceKernelLibcGettimeofday(&pspTimeval, NULL));
+	if (ret < 0)
+		return ret;
+
+	/* Return the actual time since epoch */
+	tp->tv_sec = pspTimeval.tv_sec;
+	tp->tv_nsec = 1000 * pspTimeval.tv_usec;
+
+	return 0;
+}
+#endif
+
+#ifdef F_clock_settime
+int clock_settime(clockid_t clk_id, const struct timespec *tp)
+{
+	return 0;
+}
+#endif
+
 #ifdef F__internal_malloc_lock
 void _internal_malloc_lock(struct _reent *ptr)
 {


### PR DESCRIPTION
## Description

This PR basically adds some missing functions in newlib to the `libcglue` library to make it more POSIX.