### PR TITLE
Remove 512 width/height limitation on the sceGuTexImage

### DIFF
--- a/src/gu/sceGuTexImage.c
+++ b/src/gu/sceGuTexImage.c
@@ -12,16 +12,9 @@ static int tbpcmd_tbl[8] = { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7 };		
 static int tbwcmd_tbl[8] = { 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf };		// 0x30A38
 static int tsizecmd_tbl[8] = { 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf };	// 0x30A58
 
-int getExp(int val)
+static inline int getExp(int val)
 {
-	unsigned int i;
-	asm("clz %0, %1\n":"=r"(i):"r"(val&0x3FF));
-	return 31-i;
-/*
-	unsigned int i;
-	for (i = 9; (i > 0) && !((val >> i) & 1); --i);
-	return i;
-*/
+	return 31 - __builtin_clz(val);
 }
 
 void sceGuTexImage(int mipmap, int width, int height, int tbw, const void* tbp)


### PR DESCRIPTION
## Description

Following the documentation, in sceGuTexImage function, the maximum width/height looks to be `512`.
https://github.com/pspdev/pspsdk/blob/master/src/gu/pspgu.h#L1185-L1199 

However there are too many games/apps where the minimum texture resolution is 640x480  😢 , I was wondering if that 512 is a real hardware limitation or not...

Taking a look at the implementation of sceGuTexImage I see that we have a condition of 2^9 = 512 for texture width/height.
https://github.com/pspdev/pspsdk/blob/master/src/gu/sceGuTexImage.c#L15

I have removed that condition to check if I could load for instance a texture of 1024x1024, and it worked, I have tested it in PPSSPP and real hardware.

Anyway, the current `pspsdk` behavior is `unexpected` when a user tried a bigger texture than `512`, with this PR at least we are sending to the GPU the proper value, then its up to the hardware to work or doesn't...

Thanks