### PR TITLE
Add sceGeEdramSetSize

### DIFF
--- a/src/ge/Makefile.am
+++ b/src/ge/Makefile.am
@@ -10,9 +10,9 @@ CPPFLAGS = -I$(top_srcdir)/src/base -I$(top_srcdir)/src/kernel
 CFLAGS = @PSPSDK_CFLAGS@
 CCASFLAGS = $(CFLAGS)
 
-GE_OBJS = sceGe_user_0000.o sceGe_user_0001.o sceGe_user_0002.o sceGe_user_0003.o sceGe_user_0004.o sceGe_user_0005.o sceGe_user_0006.o sceGe_user_0007.o sceGe_user_0008.o sceGe_user_0009.o sceGe_user_0010.o sceGe_user_0011.o sceGe_user_0012.o sceGe_user_0013.o sceGe_user_0014.o sceGe_user_0015.o sceGe_user_0016.o sceGe_user_0017.o sceGe_user_0018.o
+GE_OBJS = sceGe_user_0000.o sceGe_user_0001.o sceGe_user_0002.o sceGe_user_0003.o sceGe_user_0004.o sceGe_user_0005.o sceGe_user_0006.o sceGe_user_0007.o sceGe_user_0008.o sceGe_user_0009.o sceGe_user_0010.o sceGe_user_0011.o sceGe_user_0012.o sceGe_user_0013.o sceGe_user_0014.o sceGe_user_0015.o sceGe_user_0016.o sceGe_user_0017.o sceGe_user_0018.o sceGe_user_0019.o
 
-GEDRIVER_OBJS = sceGe_driver_0000.o sceGe_driver_0001.o sceGe_driver_0002.o sceGe_driver_0003.o sceGe_driver_0004.o sceGe_driver_0005.o sceGe_driver_0006.o sceGe_driver_0007.o sceGe_driver_0008.o sceGe_driver_0009.o sceGe_driver_0010.o sceGe_driver_0011.o sceGe_driver_0012.o sceGe_driver_0013.o sceGe_driver_0014.o sceGe_driver_0015.o sceGe_driver_0016.o sceGe_driver_0017.o sceGe_driver_0018.o sceGe_driver_0019.o sceGe_driver_0020.o sceGe_driver_0021.o sceGe_driver_0022.o sceGe_driver_0023.o 
+GEDRIVER_OBJS = sceGe_driver_0000.o sceGe_driver_0001.o sceGe_driver_0002.o sceGe_driver_0003.o sceGe_driver_0004.o sceGe_driver_0005.o sceGe_driver_0006.o sceGe_driver_0007.o sceGe_driver_0008.o sceGe_driver_0009.o sceGe_driver_0010.o sceGe_driver_0011.o sceGe_driver_0012.o sceGe_driver_0013.o sceGe_driver_0014.o sceGe_driver_0015.o sceGe_driver_0016.o sceGe_driver_0017.o sceGe_driver_0018.o sceGe_driver_0019.o sceGe_driver_0020.o sceGe_driver_0021.o sceGe_driver_0022.o sceGe_driver_0023.o
 
 libpspgeincludedir = @PSPSDK_INCLUDEDIR@
 libpspgeinclude_HEADERS = pspge.h

--- a/src/ge/pspge.h
+++ b/src/ge/pspge.h
@@ -74,6 +74,15 @@ typedef struct PspGeBreakParam {
 unsigned int sceGeEdramGetSize(void);
 
 /**
+ * Sets the EDRAM size to be enabled.
+ *
+ * @param size -size	The size (0x200000 or 0x400000). Will return an error if 0x400000 is specified for the PSP FAT.
+ *
+ * @return Zero on success, otherwise less than zero. 
+ */
+int sceGeEdramSetSize(int size);
+
+/**
   * Get the eDRAM address.
   *
   * @return A pointer to the base of the eDRAM.
@@ -271,6 +280,7 @@ int sceGeContinue(void);
  * @return The previous width if it was set, otherwise 0, < 0 on error.
  */
 int sceGeEdramSetAddrTranslation(int width);
+
 
 #ifdef __cplusplus
 }

--- a/src/ge/sceGe_user.S
+++ b/src/ge/sceGe_user.S
@@ -59,3 +59,6 @@
 #ifdef F_sceGe_user_0018
 	IMPORT_FUNC	"sceGe_user",0x05DB22CE,sceGeUnsetCallback
 #endif
+#ifdef F_sceGe_user_0019
+	IMPORT_FUNC	"sceGe_user",0x5BAA5439,sceGeEdramSetSize
+#endif


### PR DESCRIPTION
This was embedded into the Composite Out Plugin for DaedalusX64, i've moved it to sceGe where it belongs

It allows you to set the EDRAM (VRAM) size to 4MB for PSP Slim and higher.

More info at https://uofw.github.io/uofw/group__GE.html#ga03c96532f5c988710ef748ffccf1afbf