### PR TITLE
Fixes parameter warning in psputils

### DIFF
--- a/src/user/psputils.h
+++ b/src/user/psputils.h
@@ -14,6 +14,7 @@
 #define __UTILS_H__
 
 #include <psptypes.h>
+#include <sys/time.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This warning used to occur when including `<psputils.h>`

```bash
/usr/local/pspdev/psp/sdk/include/psputils.h:59:69: error: ‘struct timezone’ declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
   59 |   int sceKernelLibcGettimeofday(struct SceKernelTimeval *tp, struct timezone *tzp);
      |                                                                     ^~~~~~~~
cc1: all warnings being treated as errors
```

A simple search and find showed me `sys/time.h` which fixes the warning.