### PR TITLE
Fix __timezone_update() compiler warning

### DIFF
--- a/src/libcglue/timezone.c
+++ b/src/libcglue/timezone.c
@@ -27,7 +27,7 @@ void __timezone_update()
     int minutes = tzOffsetAbs - hours * 60;
     int pspDaylight = 0;
     sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_DAYLIGHTSAVINGS, &pspDaylight);
-    static char tz[18];
+    static char tz[33];
     sprintf(tz, "GMT%s%02i:%02i%s", tzOffset < 0 ? "+" : "-", hours, minutes, pspDaylight ? "daylight" : "");
     setenv("TZ", tz, 1);
 }


### PR DESCRIPTION
fix the format-overflow warning in ` __timezone_update()` function from `src\libcglue\timezone.c` by increasing the tz buffer size to 33 bytes.

<img width="554" alt="timezone_fix" src="https://user-images.githubusercontent.com/71203851/193451371-ab756ab2-f68b-4a96-abd1-04430d3c110a.png">
