### PR TITLE
fix format specifier

### DIFF
--- a/src/debug/exception.c
+++ b/src/debug/exception.c
@@ -61,13 +61,13 @@ void pspDebugDumpException(PspDebugRegBlock *regs)
 	int i;
 
 	pspDebugScreenPrintf("Exception - %s\n", codeTxt[(regs->cause >> 2) & 31]);
-	pspDebugScreenPrintf("EPC       - %08X\n", regs->epc);
-	pspDebugScreenPrintf("Cause     - %08X\n", regs->cause);
-	pspDebugScreenPrintf("Status    - %08X\n", regs->status);
-	pspDebugScreenPrintf("BadVAddr  - %08X\n", regs->badvaddr);
+	pspDebugScreenPrintf("EPC       - %08lX\n", regs->epc);
+	pspDebugScreenPrintf("Cause     - %08lX\n", regs->cause);
+	pspDebugScreenPrintf("Status    - %08lX\n", regs->status);
+	pspDebugScreenPrintf("BadVAddr  - %08lX\n", regs->badvaddr);
 	for(i = 0; i < 32; i+=4)
 	{
-		pspDebugScreenPrintf("%s:%08X %s:%08X %s:%08X %s:%08X\n", regName[i], regs->r[i],
+		pspDebugScreenPrintf("%s:%08lX %s:%08lX %s:%08lX %s:%08lX\n", regName[i], regs->r[i],
 				regName[i+1], regs->r[i+1], regName[i+2], regs->r[i+2], regName[i+3], regs->r[i+3]);
 	}
 

--- a/src/debug/profiler.c
+++ b/src/debug/profiler.c
@@ -69,28 +69,28 @@ void pspDebugProfilerPrint(void)
 	pspDebugProfilerGetRegs(&regs);
 
 	pspDebugScreenPrintf("********** Profile ***********\n");
-	pspDebugScreenPrintf("enable         : %10u\n", regs.enable);
-	pspDebugScreenPrintf("systemck       : %10u [cycles]\n", regs.systemck);
-	pspDebugScreenPrintf("cpu ck         : %10u [cycles]\n", regs.cpuck);
-	pspDebugScreenPrintf("stall          : %10u [cycles]\n", regs.internal + regs.memory +
+	pspDebugScreenPrintf("enable         : %10lu\n", regs.enable);
+	pspDebugScreenPrintf("systemck       : %10lu [cycles]\n", regs.systemck);
+	pspDebugScreenPrintf("cpu ck         : %10lu [cycles]\n", regs.cpuck);
+	pspDebugScreenPrintf("stall          : %10lu [cycles]\n", regs.internal + regs.memory +
 			regs.copz + regs.vfpu);
-	pspDebugScreenPrintf("+(internal)    : %10u [cycles]\n", regs.internal);
-	pspDebugScreenPrintf("+--(memory)    : %10u [cycles]\n", regs.memory);
-	pspDebugScreenPrintf("+----(COPz)    : %10u [cycles]\n", regs.copz);
-	pspDebugScreenPrintf("+----(VFPU)    : %10u [cycles]\n", regs.vfpu);
-	pspDebugScreenPrintf("sleep          : %10u [cycles]\n", regs.sleep);
-	pspDebugScreenPrintf("bus access     : %10u [cycles]\n", regs.bus_access);
-	pspDebugScreenPrintf("uncached load  : %10u [times]\n", regs.uncached_load);
-	pspDebugScreenPrintf("uncached store : %10u [times]\n", regs.uncached_store);
-	pspDebugScreenPrintf("cached load    : %10u [times]\n", regs.cached_load);
-	pspDebugScreenPrintf("cached store   : %10u [times]\n", regs.cached_store);
-	pspDebugScreenPrintf("I cache miss   : %10u [times]\n", regs.i_miss);
-	pspDebugScreenPrintf("D cache miss   : %10u [times]\n", regs.d_miss);
-	pspDebugScreenPrintf("D cache wb     : %10u [times]\n", regs.d_writeback);
-	pspDebugScreenPrintf("COP0 inst.     : %10u [inst.]\n", regs.cop0_inst);
-	pspDebugScreenPrintf("FPU  inst.     : %10u [inst.]\n", regs.fpu_inst);
-	pspDebugScreenPrintf("VFPU inst.     : %10u [inst.]\n", regs.vfpu_inst);
-	pspDebugScreenPrintf("local bus      : %10u [cycles]\n", regs.local_bus);
+	pspDebugScreenPrintf("+(internal)    : %10lu [cycles]\n", regs.internal);
+	pspDebugScreenPrintf("+--(memory)    : %10lu [cycles]\n", regs.memory);
+	pspDebugScreenPrintf("+----(COPz)    : %10lu [cycles]\n", regs.copz);
+	pspDebugScreenPrintf("+----(VFPU)    : %10lu [cycles]\n", regs.vfpu);
+	pspDebugScreenPrintf("sleep          : %10lu [cycles]\n", regs.sleep);
+	pspDebugScreenPrintf("bus access     : %10lu [cycles]\n", regs.bus_access);
+	pspDebugScreenPrintf("uncached load  : %10lu [times]\n", regs.uncached_load);
+	pspDebugScreenPrintf("uncached store : %10lu [times]\n", regs.uncached_store);
+	pspDebugScreenPrintf("cached load    : %10lu [times]\n", regs.cached_load);
+	pspDebugScreenPrintf("cached store   : %10lu [times]\n", regs.cached_store);
+	pspDebugScreenPrintf("I cache miss   : %10lu [times]\n", regs.i_miss);
+	pspDebugScreenPrintf("D cache miss   : %10lu [times]\n", regs.d_miss);
+	pspDebugScreenPrintf("D cache wb     : %10lu [times]\n", regs.d_writeback);
+	pspDebugScreenPrintf("COP0 inst.     : %10lu [inst.]\n", regs.cop0_inst);
+	pspDebugScreenPrintf("FPU  inst.     : %10lu [inst.]\n", regs.fpu_inst);
+	pspDebugScreenPrintf("VFPU inst.     : %10lu [inst.]\n", regs.vfpu_inst);
+	pspDebugScreenPrintf("local bus      : %10lu [cycles]\n", regs.local_bus);
 }
 
 


### PR DESCRIPTION
This PR is fixed for format specifier warnings in `exception.c` and `profiler.c` from `src/debug`. Please see these [warning logs](https://gist.github.com/diamant3/c6f818eb1b53d7fa702bd07191e74f6b).

I did not touch the `stacktrace.c` and `pspdebugkb.c` warnings because they are not the same issue.