### PR TITLE
fix restrict warning

### DIFF
--- a/src/debug/pspdebugkb.c
+++ b/src/debug/pspdebugkb.c
@@ -251,8 +251,8 @@ void pspDebugKbInit(char* str) {
 	  break;
 	case 1: // Space
 	  if (strlen(str) < PSP_DEBUG_KB_MAXLEN) {
-	    char out[PSP_DEBUG_KB_MAXLEN] = {0};
-	    snprintf(out, strlen(str), "%s ", str);
+	    char out[PSP_DEBUG_KB_MAXLEN + 2];
+	    snprintf(out, sizeof(out), "%s ", str);
 	    pspDebugKbDrawString(out);
 	  }
 	  break;
@@ -273,8 +273,8 @@ void pspDebugKbInit(char* str) {
 	};
       } else {
 	if (strlen(str) < PSP_DEBUG_KB_MAXLEN) {
-	  char out[PSP_DEBUG_KB_MAXLEN] = {0};
-	  snprintf(out, strlen(str), "%s%c", str, charTable[row][col]);
+	  char out[PSP_DEBUG_KB_MAXLEN + 2];
+	  snprintf(out, sizeof(out), "%s%c", str, charTable[row][col]);
 	  pspDebugKbDrawString(out);
 	}
       }

--- a/src/debug/pspdebugkb.c
+++ b/src/debug/pspdebugkb.c
@@ -251,7 +251,7 @@ void pspDebugKbInit(char* str) {
 	  break;
 	case 1: // Space
 	  if (strlen(str) < PSP_DEBUG_KB_MAXLEN) {
-      char out[PSP_DEBUG_KB_MAXLEN] = {0};
+	    char out[PSP_DEBUG_KB_MAXLEN] = {0};
 	    snprintf(out, strlen(str), "%s ", str);
 	    pspDebugKbDrawString(out);
 	  }
@@ -273,7 +273,7 @@ void pspDebugKbInit(char* str) {
 	};
       } else {
 	if (strlen(str) < PSP_DEBUG_KB_MAXLEN) {
-    char out[PSP_DEBUG_KB_MAXLEN] = {0};
+	  char out[PSP_DEBUG_KB_MAXLEN] = {0};
 	  snprintf(out, strlen(str), "%s%c", str, charTable[row][col]);
 	  pspDebugKbDrawString(out);
 	}

--- a/src/debug/pspdebugkb.c
+++ b/src/debug/pspdebugkb.c
@@ -251,8 +251,9 @@ void pspDebugKbInit(char* str) {
 	  break;
 	case 1: // Space
 	  if (strlen(str) < PSP_DEBUG_KB_MAXLEN) {
-	    snprintf(str, strlen(str)+2, "%s ", str);
-	    pspDebugKbDrawString(str);
+      char out[PSP_DEBUG_KB_MAXLEN] = {0};
+	    snprintf(out, strlen(str), "%s ", str);
+	    pspDebugKbDrawString(out);
 	  }
 	  break;
 	case 2: // Back
@@ -272,8 +273,9 @@ void pspDebugKbInit(char* str) {
 	};
       } else {
 	if (strlen(str) < PSP_DEBUG_KB_MAXLEN) {
-	  snprintf(str, strlen(str)+2, "%s%c", str, charTable[row][col]);
-	  pspDebugKbDrawString(str);
+    char out[PSP_DEBUG_KB_MAXLEN] = {0};
+	  snprintf(out, strlen(str), "%s%c", str, charTable[row][col]);
+	  pspDebugKbDrawString(out);
 	}
       }
     }


### PR DESCRIPTION
This is the issue:

<img width="611" alt="snprintf" src="https://user-images.githubusercontent.com/71203851/195869632-1012d049-e759-4a08-b01e-fb7e23b432d2.png">

Solution: 

I defined a temporary `out` buffer with the size of `PSP_DEBUG_KB_MAXLEN` and filled it with zeroes for `snprintf` to prevent truncation of the input string(`str` parameter).