### PR TITLE
fix error: ‘fd_set’ has not been declared

### DIFF
--- a/src/net/psphttp.h
+++ b/src/net/psphttp.h
@@ -13,6 +13,8 @@
 #ifndef __PSPHTTP_H__
 #define __PSPHTTP_H__
 
+#include <pspkerneltypes.h>
+
 #if defined(__cplusplus)
 extern "C" {
 #endif

--- a/src/net/pspnet_inet.h
+++ b/src/net/pspnet_inet.h
@@ -19,6 +19,7 @@ extern "C" {
 #endif
 
 #include <sys/socket.h>
+#include <sys/select.h>
 
 /** 
  *  This struct is needed because tv_sec size is different from what newlib expect


### PR DESCRIPTION
When including just `pspnet_inet.h` the following error occurs:

```bash
In file included from /projects/PSP/File-Downloader/main.cpp:8:
/usr/local/pspdev/psp/sdk/include/pspnet_inet.h:36:33: error: ‘fd_set’ has not been declared
   36 |     int sceNetInetSelect(int n, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct SceNetInetTimeval *timeout);
      |                                 ^~~~~~
/usr/local/pspdev/psp/sdk/include/pspnet_inet.h:36:50: error: ‘fd_set’ has not been declared
   36 |     int sceNetInetSelect(int n, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct SceNetInetTimeval *timeout);
      |                                                  ^~~~~~
/usr/local/pspdev/psp/sdk/include/pspnet_inet.h:36:68: error: ‘fd_set’ has not been declared
   36 |     int sceNetInetSelect(int n, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct SceNetInetTimeval *timeout);
      |                                                                    ^~~~~~
make[2]: *** [CMakeFiles/File_Downloader.dir/build.make:76: CMakeFiles/File_Downloader.dir/main.cpp.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/File_Downloader.dir/all] Error 2
make: *** [Makefile:91: all] Error 2          
```

This PR attempts to solve this issue by including the needed headers :)