### PR TITLE
fix unused result warning

### DIFF
--- a/tools/PrxEncrypter/main.c
+++ b/tools/PrxEncrypter/main.c
@@ -181,7 +181,12 @@ int load_elf(char *elff)
 	fseek(fp, 0, SEEK_END);
 	int size = ftell(fp);
 	fseek(fp, 0, SEEK_SET);
-	fread(elf, 1, size, fp);
+	size_t result = fread(elf, 1, size, fp);
+	if (result < 0) {
+		fprintf(stderr, "Error, could not read the ELF\n");
+		fclose(fp);
+		return -1;
+	}
 	fclose(fp);
 
 	return size;

--- a/tools/pack-pbp.c
+++ b/tools/pack-pbp.c
@@ -158,7 +158,8 @@ int main(int argc, char *argv[]) { int loop0, result;
          }
          
          // Read in the data from the file
-         if (fread(buffer, readsize, 1, infile) < 0) {
+         size_t result = fread(buffer, readsize, 1, infile);
+         if (result < 0) {
             printf("ERROR: Could not read in the file data. (%s)\n", argv[2 + loop0]);
             return -1;
          }

--- a/tools/psp-fixup-imports.c
+++ b/tools/psp-fixup-imports.c
@@ -195,7 +195,12 @@ unsigned char *load_file(const char *file, unsigned int *size)
 				break;
 			}
 
-			(void) fread(data, 1, *size, fp);
+			size_t result = fread(data, 1, *size, fp);
+			if (result < 0) {
+				fprintf(stderr, "Error, could not read the ELF\n");
+				fclose(fp);
+				break;
+			}
 			fclose(fp);
 		}
 		else

--- a/tools/psp-prxgen.c
+++ b/tools/psp-prxgen.c
@@ -144,7 +144,12 @@ unsigned char *load_file(const char *file)
 				break;
 			}
 
-			(void) fread(data, 1, size, fp);
+			size_t result = fread(data, 1, size, fp);
+			if (result < 0) {
+				fprintf(stderr, "Error, could not read the ELF\n");
+				fclose(fp);
+				break;
+			}
 			fclose(fp);
 		}
 		else

--- a/tools/unpack-pbp.c
+++ b/tools/unpack-pbp.c
@@ -96,7 +96,8 @@ int main(int argc, char *argv[]) {
    }
    
    // Read in the header
-   if (fread(&header, sizeof(HEADER), 1, infile) < 0) {
+   size_t result = fread(&header, sizeof(HEADER), 1, infile);
+   if (result < 0) {
       printf("ERROR: Could not read the input file header.\n");
       return -1;
    }
@@ -168,7 +169,8 @@ int main(int argc, char *argv[]) {
          size -= readsize;
          
          // Read in the data from the PBP
-         if (fread(buffer, readsize, 1, infile) < 0) {
+         size_t result = fread(buffer, readsize, 1, infile);
+         if (result < 0) {
             printf("ERROR: Could not read in the section data.\n");
             free(buffer);
             return -1;


### PR DESCRIPTION
This is the fix for those warnings :)

**screenshots**:

<img width="727" alt="prxencrypter" src="https://user-images.githubusercontent.com/71203851/213365615-334158a6-55f7-469b-973e-2f8fcc3c6f55.png">

<img width="756" alt="others" src="https://user-images.githubusercontent.com/71203851/213365653-cd575070-93c6-4764-938b-6137d07668dd.png">