### PR TITLE
Set cmake system to PSP instead of generic

### DIFF
--- a/src/base/pspdev.cmake
+++ b/src/base/pspdev.cmake
@@ -4,7 +4,7 @@ else()
     message(FATAL_ERROR "The environment variable PSPDEV needs to be defined.")
 endif()
 
-SET(CMAKE_SYSTEM_NAME Generic)
+SET(CMAKE_SYSTEM_NAME PSP)
 SET(CMAKE_SYSTEM_VERSION 1)
 SET(CMAKE_SYSTEM_PROCESSOR mips)
 SET(CMAKE_C_COMPILER psp-gcc)


### PR DESCRIPTION
Addresses this issue: https://github.com/pspdev/pspdev/issues/41

I'd like for it to be reviewed, because I do not know if it will cause any breakage yet. I'll do some testing with it.