### PR TITLE
pspdev.cmake: Fix pkg-config support

### DIFF
--- a/src/base/pspdev.cmake
+++ b/src/base/pspdev.cmake
@@ -22,7 +22,7 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
-SET(PKG_CONFIG_EXECUTABLE "${PSPDEV}/bin/psp-pkg-config")
+SET(PKG_CONFIG_EXECUTABLE "${PSPDEV}/bin/psp-pkg-config" CACHE STRING "Path to pkg-config")
 
 ## Add Default PSPSDK Libraries according to build.mak and add stdc++ for C++ builds so this doesn't need to be done manually later
 include_directories(${PSPDEV}/psp/include ${PSPDEV}/psp/sdk/include)


### PR DESCRIPTION
`PKG_CONFIG_EXECUTABLE` must be a cache variable, otherwise only the first call to `find_program(PkgConfig)` succeeds.