### PR TITLE
build.mak: Improve and streamline .SFO creation

### DIFF
--- a/src/base/build.mak
+++ b/src/base/build.mak
@@ -21,7 +21,7 @@ LD       = psp-gcc
 AR       = psp-gcc-ar
 RANLIB   = psp-gcc-ranlib
 STRIP    = psp-strip
-MKSFO    = mksfo
+MKSFO    = mksfoex
 PACK_PBP = pack-pbp
 FIXUP    = psp-fixup-imports
 ENC		 = PrxEncrypter
@@ -34,13 +34,27 @@ CFLAGS   := $(addprefix -I,$(INCDIR)) -G0 $(CFLAGS)
 CXXFLAGS := $(CFLAGS) $(CXXFLAGS)
 ASFLAGS  := $(CFLAGS) $(ASFLAGS)
 
-ifeq ($(PSP_LARGE_MEMORY),1)
-MKSFO = mksfoex -d MEMSIZE=1
-endif
-
 ifeq ($(PSP_FW_VERSION),)
 PSP_FW_VERSION=150
 endif
+
+# CFW versions after M33 3.90 guard against expanding the
+# user memory partition on PSP-1000, making MEMSIZE obsolete.
+# It is now an opt-out policy with PSP_LARGE_MEMORY=0
+ifeq ($(shell test $(PSP_FW_VERSION) -gt 390; echo $$?),0)
+ifeq ($(PSP_LARGE_MEMORY),1)
+$(warning "PSP_LARGE_MEMORY" flag is not necessary targeting firmware versions above 3.90)
+else ifeq ($(PSP_LARGE_MEMORY),0)
+SFOFLAGS := -d MEMSIZE=0 $(SFOFLAGS)
+else
+SFOFLAGS := -d MEMSIZE=1 $(SFOFLAGS)
+endif
+else
+ifeq ($(PSP_LARGE_MEMORY),1)
+SFOFLAGS := -d MEMSIZE=1 $(SFOFLAGS)
+endif
+endif
+
 
 CFLAGS += -D_PSP_FW_VERSION=$(PSP_FW_VERSION)
 CXXFLAGS += -D_PSP_FW_VERSION=$(PSP_FW_VERSION)
@@ -152,7 +166,7 @@ $(TARGET_LIB): $(OBJS)
 	$(RANLIB) $@
 
 $(PSP_EBOOT_SFO): 
-	$(MKSFO) '$(PSP_EBOOT_TITLE)' $@
+	$(MKSFO) $(SFOFLAGS) '$(PSP_EBOOT_TITLE)' $@
 
 ifeq ($(BUILD_PRX),1)
 $(PSP_EBOOT): $(TARGET).prx $(PSP_EBOOT_SFO)

--- a/src/base/build.mak
+++ b/src/base/build.mak
@@ -38,23 +38,25 @@ ifeq ($(PSP_FW_VERSION),)
 PSP_FW_VERSION=150
 endif
 
+EXPAND_MEMORY = 0
+
 # CFW versions after M33 3.90 guard against expanding the
 # user memory partition on PSP-1000, making MEMSIZE obsolete.
 # It is now an opt-out policy with PSP_LARGE_MEMORY=0
 ifeq ($(shell test $(PSP_FW_VERSION) -gt 390; echo $$?),0)
+EXPAND_MEMORY = 1
 ifeq ($(PSP_LARGE_MEMORY),1)
 $(warning "PSP_LARGE_MEMORY" flag is not necessary targeting firmware versions above 3.90)
 else ifeq ($(PSP_LARGE_MEMORY),0)
-SFOFLAGS := -d MEMSIZE=0 $(SFOFLAGS)
-else
-SFOFLAGS := -d MEMSIZE=1 $(SFOFLAGS)
-endif
+EXPAND_MEMORY = 0
+endif # PSP_LARGE_MEMORY
 else
 ifeq ($(PSP_LARGE_MEMORY),1)
-SFOFLAGS := -d MEMSIZE=1 $(SFOFLAGS)
-endif
-endif
+EXPAND_MEMORY = 1
+endif # PSP_LARGE_MEMORY
+endif # PSP_FW_VERSION
 
+SFOFLAGS := -d MEMSIZE=$(EXPAND_MEMORY) $(SFOFLAGS)
 
 CFLAGS += -D_PSP_FW_VERSION=$(PSP_FW_VERSION)
 CXXFLAGS += -D_PSP_FW_VERSION=$(PSP_FW_VERSION)


### PR DESCRIPTION
The current state of building .SFO binaries is rather primitive -- as it stood, build.mak forced its own flags to be used, always. If you were building without PSP_LARGE_MEMORY, build.mak would use a deprecated tool for generation as well, one that cobbles together undocumented flags in an array of bytes and shoving it into a file.

The first change this commit makes is by enabling use of the "new" mkfsoex at all times, which creates a smaller but still bootable SFO without any arguments given. Developers are able to provide custom SFO flags now using this, added via `SFOFLAGS` in their Makefile.

This means that developers can now (at their own discretion) provide custom region information, parental control level, minimum firmware boot level, etc. with:

```make
SFOFLAGS = -d REGION=16394 -d PARENTAL_LEVEL=4 -s PSP_SYSTEM_VER="4.01"
```

As a side-effect, this also makes the SDK more adapted to new custom firmware releases that may add new SFO flags.

The second change made is turning `PSP_LARGE_MEMORY` into an opt-out /enabled by default flag if developers are targeting a firmware version newer than 3.90. Custom firmware versions starting from 4.01 M33 guard against expanding the user memory partition to 52mB if the unit detected is PSP-1000. Therefore having this check in place becomes redundant, potentially complicating Makefiles. A warning is printed out allowing developers to be aware of this fact and removing the flag from their Makefile.