### PR TITLE
SceNetAdhocctlParams: Swap order of BSSID and Nickname

### DIFF
--- a/src/net/pspnet_adhocctl.h
+++ b/src/net/pspnet_adhocctl.h
@@ -74,10 +74,10 @@ struct SceNetAdhocctlParams
 	int channel;
 	/** Name of the connection */
 	char name[8];
-	/** The BSSID */
-	unsigned char bssid[6];
 	/** Nickname */
 	char nickname[128];
+	/** The BSSID */
+	unsigned char bssid[6];
 };
 
 /**


### PR DESCRIPTION
Prompted by #46, I have taken the time looking at `pspnet_adhocctl.prx` in older firmware versions via Ghidra (thanks @sajattack) and some early Adhoc-capable titles like Ridge Racer and Hot Shot's Golf, I have concluded that the order of elements in the `SceNetAdhocctlParams` struct to have always been `nickname`, followed by `bssid`. Not changed in any later firmware revision. This PR resolves this discrepancy.