### PR TITLE
Guard `_PSP_FW_VERSION` macro to mitigate warnings with `-Wundef`

### DIFF
--- a/src/kernel/psploadexec_kernel.h
+++ b/src/kernel/psploadexec_kernel.h
@@ -47,7 +47,7 @@ struct SceKernelLoadExecVSHParam {
     u32 unk5;
 }; 
 
-#if _PSP_FW_VERSION < 200
+#if defined(_PSP_FW_VERSION) && _PSP_FW_VERSION < 200
 /**
  * Executes a new executable from a buffer.
  *
@@ -72,7 +72,7 @@ int sceKernelLoadExecBufferPlain(SceSize bufsize, void *buf, struct SceKernelLoa
 */
 int sceKernelExitVSHVSH(struct SceKernelLoadExecVSHParam *param);
 
-#if _PSP_FW_VERSION >= 200
+#if defined(_PSP_FW_VERSION) && _PSP_FW_VERSION >= 200
 /**
  * Restart the vsh (to be used by a kernel module)
  *
@@ -141,7 +141,7 @@ int sceKernelLoadExecVSHMs2(const char *file, struct SceKernelLoadExecVSHParam *
 */
 int sceKernelLoadExecVSHMs3(const char *file, struct SceKernelLoadExecVSHParam *param);
 
-#if _PSP_FW_VERSION >= 300
+#if defined(_PSP_FW_VERSION) && _PSP_FW_VERSION >= 300
 /***
  * Executes a new executable from a memory stick.
  * It is the function used by the firmware to execute psx games

--- a/src/kernel/pspthreadman_kernel.h
+++ b/src/kernel/pspthreadman_kernel.h
@@ -193,7 +193,7 @@ typedef struct SceKernelThreadKInfo {
 	int     	wakeupCount;
 	/** Number of clock cycles run */
 	SceKernelSysClock   runClocks;
-#if _PSP_FW_VERSION >= 200
+#if defined(_PSP_FW_VERSION) && _PSP_FW_VERSION >= 200
 	SceUInt unk3; /* Unknown extra field on later firmwares */
 #endif
 	/** Interrupt preemption count */

--- a/src/samples/savedata/utility/main.c
+++ b/src/samples/savedata/utility/main.c
@@ -27,7 +27,7 @@
 
 PSP_MODULE_INFO("Savedata Sample", 0, 1, 1);
 
-#if _PSP_FW_VERSION >= 200
+#if defined(_PSP_FW_VERSION) && _PSP_FW_VERSION >= 200
 PSP_HEAP_SIZE_KB(20480);
 #endif
 
@@ -231,7 +231,7 @@ void initSavedata(SceUtilitySavedataParam * savedata, int mode)
 	savedata->overwrite = 1;
 	savedata->focus = PSP_UTILITY_SAVEDATA_FOCUS_LATEST; // Set initial focus to the newest file (for loading)
 
-#if _PSP_FW_VERSION >= 200
+#if defined(_PSP_FW_VERSION) && _PSP_FW_VERSION >= 200
 	strncpy(savedata->key, key, 16);
 #endif
 

--- a/src/samples/utility/netdialog/main.c
+++ b/src/samples/utility/netdialog/main.c
@@ -23,7 +23,7 @@
 #include <pspnet_inet.h>
 #include <pspnet_apctl.h>
 
-#if _PSP_FW_VERSION >= 200
+#if _defined(_PSP_FW_VERSION) && PSP_FW_VERSION >= 200
 PSP_MODULE_INFO("Net Dialog Sample", 0, 1, 1);
 #else
 PSP_MODULE_INFO("Net Dialog Sample", 0x1000, 1, 1);
@@ -281,7 +281,7 @@ int user_thread(SceSize args, void *argp)
 /* main routine */
 int main(int argc, char *argv[])
 {
-	#if _PSP_FW_VERSION >= 200
+	#if defined(_PSP_FW_VERSION) && _PSP_FW_VERSION >= 200
 	sceUtilityLoadNetModule(PSP_NET_MODULE_COMMON);
 
 	sceUtilityLoadNetModule(PSP_NET_MODULE_INET);

--- a/src/user/pspsysmem.h
+++ b/src/user/pspsysmem.h
@@ -102,7 +102,7 @@ SceSize sceKernelMaxFreeMemSize(void);
  */
 int sceKernelDevkitVersion(void);
 
-#if _PSP_FW_VERSION >= 150
+#if defined(_PSP_FW_VERSION) && _PSP_FW_VERSION >= 150
 
 /**
  * Kernel printf function.

--- a/src/utility/psputility_savedata.h
+++ b/src/utility/psputility_savedata.h
@@ -126,7 +126,7 @@ typedef struct SceUtilitySavedataParam
 	/** unknown2: ? */
 	int unknown2[4];
 
-#if _PSP_FW_VERSION >= 200
+#if defined(_PSP_FW_VERSION) && _PSP_FW_VERSION >= 200
 
 	/** key: encrypt/decrypt key for save with firmware >= 2.00 */
 	char key[16];


### PR DESCRIPTION
Fixes #123. Guards `_PSP_FW_VERSION` references with `#if defined()` to avoid the SDK headers returning warnings when compiling modules with the `-Wundef` cflag.