### PR TITLE
Do not rebuild every day

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,6 @@ on:
       - master
     tags:
       - v*
-  schedule:
-      - cron: 0 7 * * *
   repository_dispatch:
     types: [run_build]
 


### PR DESCRIPTION
Daily was too often and this will be rebuild weekly with the changes to psptoolchain-allegrex anyway, because of the cascading effect build into the repos.