### PR TITLE
ATRAC3: Fix mysterious "uint" type reference in pspatrac3.h

### DIFF
--- a/src/atrac3/pspatrac3.h
+++ b/src/atrac3/pspatrac3.h
@@ -66,7 +66,7 @@ typedef struct {
 	u32 uiReadPositionSecondBuf;
 } PspBufferInfo;
 
-int sceAtracGetAtracID(uint  uiCodecType);
+int sceAtracGetAtracID(u32  uiCodecType);
 
 /**
  * Creates a new Atrac ID from the specified data


### PR DESCRIPTION
Not sure where this originated. Possibly a leftover from old SDK versions since the uint type appears in some archaic homebrew as well. This was the only reference of `uint` in the entire SDK. Went ahead and changed this appropriately to `u32`. File is unable to be included into most workflows without this change.