### PR TITLE
Implement full LOCK API for newlib

### DIFF
--- a/src/libcglue/Makefile.am
+++ b/src/libcglue/Makefile.am
@@ -27,13 +27,16 @@ FDMAN_OBJS = __descriptor_data_pool.o __descriptormap.o __fdman_init.o __fdman_g
 GLUE_OBJS = __dummy_passwd.o __fill_stat.o __psp_heap_blockid.o __psp_free_heap.o _fork.o _wait.o _open.o _close.o _read.o \
 	_write.o _fstat.o _stat.o lstat.o access.o _fcntl.o  _lseek.o chdir.o mkdir.o rmdir.o getdents.o _seekdir.o _link.o _unlink.o \
 	_rename.o _getpid.o _kill.o _sbrk.o _gettimeofday.o _times.o ftime.o clock_getres.o clock_gettime.o clock_settime.o \
-	_internal_malloc_lock.o _internal_malloc_unlock.o _isatty.o symlink.o truncate.o chmod.o fchmod.o fchmodat.o pathconf.o \
-	readlink.o utime.o fchown.o getentropy.o getpwuid.o fsync.o getpwnam.o getuid.o geteuid.o basename.o
-
+	_isatty.o symlink.o truncate.o chmod.o fchmod.o fchmodat.o pathconf.o readlink.o utime.o fchown.o getentropy.o getpwuid.o \
+	fsync.o getpwnam.o getuid.o geteuid.o basename.o
 
 INIT_OBJS = __libpthreadglue_init.o __libcglue_init.o __libcglue_deinit.o _exit.o abort.o exit.o
 
-MUTEXMAN_OBJS = __malloc_mutex.o __sbrk_mutex.o __fdman_mutex.o __init_mutex.o __deinit_mutex.o
+LOCK_OBJS = __retarget_lock_init.o __retarget_lock_acquire.o __retarget_lock_release.o __retarget_lock_try_acquire.o \
+	__retarget_lock_close.o __retarget_lock_init_recursive.o __retarget_lock_acquire_recursive.o __retarget_lock_release_recursive.o \
+	__retarget_lock_try_acquire_recursive.o __retarget_lock_close_recursive.o
+
+MUTEXMAN_OBJS = __sbrk_mutex.o __fdman_mutex.o __init_mutex.o __deinit_mutex.o
 
 NETDB_OBJS = h_errno.o gethostbyaddr.o gethostbyname.o
 
@@ -76,8 +79,8 @@ libcglue_a_SOURCES = \
 	socket.c \
 	timezone.c
 
-libcglue_a_LIBADD  = $(CWD_OBJS) $(ERRNO_OBJS) $(FDMAN_OBJS) $(INIT_OBJS) $(GLUE_OBJS) $(MUTEXMAN_OBJS) $(NETDB_OBJS) $(PIPE_OBJS) \
-	$(SELECT_OBJS) $(SOCKET_OBJS) $(SLEEP_OBJS) $(TIMEZONE_OBJS)
+libcglue_a_LIBADD  = $(CWD_OBJS) $(ERRNO_OBJS) $(FDMAN_OBJS) $(GLUE_OBJS) $(INIT_OBJS) $(LOCK_OBJS) $(MUTEXMAN_OBJS) \
+	$(NETDB_OBJS) $(PIPE_OBJS) $(SELECT_OBJS) $(SOCKET_OBJS) $(SLEEP_OBJS) $(TIMEZONE_OBJS)
 
 $(CWD_OBJS): cwd.c
 	$(AM_V_CC)$(COMPILE) -DF_$* $< -c -o $@
@@ -88,10 +91,13 @@ $(ERRNO_OBJS): errno.c
 $(FDMAN_OBJS): fdman.c
 	$(AM_V_CC)$(COMPILE) -DF_$* $< -c -o $@
 
+$(GLUE_OBJS): glue.c
+	$(AM_V_CC)$(COMPILE) -DF_$* $< -c -o $@
+
 $(INIT_OBJS): init.c
 	$(AM_V_CC)$(COMPILE) -DF_$* $< -c -o $@
 
-$(GLUE_OBJS): glue.c
+$(LOCK_OBJS): lock.c
 	$(AM_V_CC)$(COMPILE) -DF_$* $< -c -o $@
 
 $(MUTEXMAN_OBJS): mutexman.c

--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -54,7 +54,6 @@ int __get_drive(const char *d);
 int __path_absolute(const char *in, char *out, int len);
 
 /* Functions from mutexman.c */
-extern SceLwMutexWorkarea __malloc_mutex;
 extern SceLwMutexWorkarea __sbrk_mutex;
 
 /* Fuctions from errno.c */
@@ -798,20 +797,6 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp)
 int clock_settime(clockid_t clk_id, const struct timespec *tp)
 {
 	return 0;
-}
-#endif
-
-#ifdef F__internal_malloc_lock
-void _internal_malloc_lock(struct _reent *ptr)
-{
-	sceKernelLockLwMutex(&__malloc_mutex, 1, 0);
-}
-#endif
-
-#ifdef F__internal_malloc_unlock
-void _internal_malloc_unlock(struct _reent *ptr)
-{
-	sceKernelUnlockLwMutex(&__malloc_mutex, 1);
 }
 #endif
 

--- a/src/libcglue/lock.c
+++ b/src/libcglue/lock.c
@@ -1,0 +1,112 @@
+/*
+ * PSP Software Development Kit - https://github.com/pspdev
+ * -----------------------------------------------------------------------
+ * Licensed under the BSD license, see LICENSE in PSPSDK root for details.
+ *
+ * sleep.c - Sleep functions needed by newlib.
+ *
+ * Copyright (c) 2023 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+ *
+ */
+
+/**
+ * @file
+ * The lock API functions required by newlib.
+ */
+
+#include <stdio.h>
+#include <sys/lock.h>
+#include <pspthreadman.h>
+
+// Structure representing the lock
+struct __lock {
+    SceLwMutexWorkarea mutex;
+    int32_t thread_id;
+    int32_t count;
+};
+
+#ifdef F___retarget_lock_init
+void __retarget_lock_init(_LOCK_T *lock)
+{
+    sceKernelCreateLwMutex(&(*lock)->mutex, "lock API mutex", 0, 0, 0);
+}
+#endif
+
+#ifdef F___retarget_lock_acquire
+void __retarget_lock_acquire(_LOCK_T lock)
+{
+	sceKernelLockLwMutex(&lock->mutex, 1, 0);
+}
+#endif
+
+#ifdef F___retarget_lock_release
+void __retarget_lock_release(_LOCK_T lock)
+{
+	sceKernelUnlockLwMutex(&lock->mutex, 1);
+}
+#endif
+
+#ifdef F___retarget_lock_try_acquire
+int __retarget_lock_try_acquire(_LOCK_T lock)
+{
+	return sceKernelTryLockLwMutex(&lock->mutex, 1);
+}
+#endif
+
+#ifdef F___retarget_lock_close
+void __retarget_lock_close(_LOCK_T lock)
+{
+    sceKernelDeleteLwMutex(&lock->mutex);
+}
+#endif
+
+#ifdef F___retarget_lock_init_recursive
+void __retarget_lock_init_recursive(_LOCK_T *lock)
+{
+	sceKernelCreateLwMutex(&(*lock)->mutex, "lock API recursive mutex", 0, 0, 0);
+    (*lock)->count = 0;
+    (*lock)->thread_id = sceKernelGetThreadId();
+}
+#endif
+
+#ifdef F___retarget_lock_acquire_recursive
+void __retarget_lock_acquire_recursive(_LOCK_T lock)
+{
+    int32_t thread_id = sceKernelGetThreadId();
+    if (lock->count == 0 || lock->thread_id != thread_id) {
+        sceKernelLockLwMutex(&lock->mutex, 1, 0);
+    }
+    lock->count++;
+}
+#endif
+
+#ifdef F___retarget_lock_release_recursive
+void __retarget_lock_release_recursive(_LOCK_T lock)
+{
+    int32_t thread_id = sceKernelGetThreadId();
+    if (lock->count == 1 || lock->thread_id != thread_id) {
+        sceKernelUnlockLwMutex(&lock->mutex, 1);
+    }
+    lock->count--;
+}
+#endif
+
+#ifdef F___retarget_lock_try_acquire_recursive
+int __retarget_lock_try_acquire_recursive(_LOCK_T lock)
+{
+    int res = 0;
+    int32_t thread_id = sceKernelGetThreadId();
+    if (lock->count == 0 || lock->thread_id != thread_id) {
+        res = sceKernelTryLockLwMutex(&lock->mutex, 1) != 0;
+    }
+    lock->count++;
+    return res;
+}
+#endif
+
+#ifdef F___retarget_lock_close_recursive
+void __retarget_lock_close_recursive(_LOCK_T lock)
+{
+    sceKernelDeleteLwMutex(&lock->mutex);
+}
+#endif

--- a/src/libcglue/mutexman.c
+++ b/src/libcglue/mutexman.c
@@ -16,12 +16,6 @@
 #include <string.h>
 #include <pspthreadman.h>
 
-#ifdef F___malloc_mutex
-SceLwMutexWorkarea __malloc_mutex;
-#else
-extern SceLwMutexWorkarea __malloc_mutex;
-#endif
-
 #ifdef F___sbrk_mutex
 SceLwMutexWorkarea __sbrk_mutex;
 #else
@@ -38,7 +32,6 @@ extern SceLwMutexWorkarea __fdman_mutex;
 /* Create mutex used for making thread safe mallock and get fd */
 void __init_mutex()
 {
-	sceKernelCreateLwMutex(&__malloc_mutex, "malloc mutex", 0, 0, 0);
 	sceKernelCreateLwMutex(&__sbrk_mutex, "sbrk mutex", 0, 0, 0);
 	sceKernelCreateLwMutex(&__fdman_mutex, "fdman mutex", 0, 0, 0);
 }
@@ -48,7 +41,6 @@ void __init_mutex()
 /* Create mutex used for making thread safe mallock and get fd */
 void __deinit_mutex()
 {
-	sceKernelDeleteLwMutex(&__malloc_mutex);
 	sceKernelDeleteLwMutex(&__sbrk_mutex);
 	sceKernelDeleteLwMutex(&__fdman_mutex);
 }

--- a/src/rtc/psprtc.h
+++ b/src/rtc/psprtc.h
@@ -13,6 +13,8 @@
 #ifndef __PSPRTC_H__
 #define __PSPRTC_H__
 
+#include <time.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This PR brings a full thread-safe environment in all the I/O operations from newlib.

Previously we were using `_internal_malloc_lock` and `_internal_malloc_unlock` that made thread-safe alloc/dealloc operations.

Now implementing the lock API, we will have a thread-safer environment.

This PR requires to merge first: https://github.com/pspdev/psptoolchain-allegrex/pull/14