### PR TITLE
Add dependencies for building packages to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,3 +33,5 @@ ENV PSPDEV /usr/local/pspdev
 ENV PATH $PATH:${PSPDEV}/bin
 
 COPY --from=0 ${PSPDEV} ${PSPDEV}
+RUN apk add --no-cache build-base bash acl sudo fakeroot curl patch gpgme-dev libarchive-tools libarchive-dev xz \
+    openssl-dev git bison autoconf automake tcl-dev libtool cmake doxygen texinfo flex pkgconf libcrypto1.1


### PR DESCRIPTION
The pspsdk container is only used by psp-packages and psplinkusb. In the psp-packages actions we are installing the dependencies needing for building packages over 30 times. This is a waste of time and resources (it's also kinda mean towards the Alpine Linux team). My suggestion is to make sure those dependencies are already available in this container. This would probably make psp-packages build 10 times faster.