### PR TITLE
Fix init / libc_init ordering

### DIFF
--- a/src/startup/crt0_prx.c
+++ b/src/startup/crt0_prx.c
@@ -58,8 +58,6 @@ void _main(SceSize args, void *argp)
 	int loc = 0;
 	char *ptr = argp;
 
-	_init();
-
 	/* Turn our thread arguments into main()'s argc and argv[]. */
 	while(loc < args)
 	{
@@ -76,6 +74,9 @@ void _main(SceSize args, void *argp)
 
 	/* Call libc initialization hook */
 	__libcglue_init(argc, argv);	
+
+	/* Init can contain C++ constructors that require working threading */
+	_init();
 
 	/* Make sure _fini() is called when the program ends. */
 	atexit((void *) _fini);


### PR DESCRIPTION
_init might require working pthreads, due to C++ constructors using mutexes and threads. Since libc does not require _init execution, we simply reorder them.

This removes support for kernel-mode _init on user programs that run in kernel mode (mostly old FW 1.5, but should not affect almost any homebrew out there, since they don't use user-mode main thread).