### PR TITLE
gu: Add clang-friendly codepath

### DIFF
--- a/src/gu/sceGuTexImage.c
+++ b/src/gu/sceGuTexImage.c
@@ -14,13 +14,7 @@ static int tsizecmd_tbl[8] = { 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf };
 
 int getExp(int val)
 {
-#ifndef __clang__
-	unsigned int i;
-	asm("clz %0, %1\n":"=r"(i):"r"(val&0x3FF));
-	return 31-i;
-#else
 	return 31 - __builtin_clz(val & 0x3FF);
-#endif
 }
 
 void sceGuTexImage(int mipmap, int width, int height, int tbw, const void* tbp)

--- a/src/gu/sceGuTexImage.c
+++ b/src/gu/sceGuTexImage.c
@@ -19,9 +19,7 @@ int getExp(int val)
 	asm("clz %0, %1\n":"=r"(i):"r"(val&0x3FF));
 	return 31-i;
 #else
-	unsigned int i;
-	for (i = 9; (i > 0) && !((val >> i) & 1); --i);
-	return i;
+	return 31 - __builtin_clz(val & 0x3FF);
 #endif
 }
 

--- a/src/gu/sceGuTexImage.c
+++ b/src/gu/sceGuTexImage.c
@@ -14,14 +14,15 @@ static int tsizecmd_tbl[8] = { 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf };
 
 int getExp(int val)
 {
+#ifndef __clang__
 	unsigned int i;
 	asm("clz %0, %1\n":"=r"(i):"r"(val&0x3FF));
 	return 31-i;
-/*
+#else
 	unsigned int i;
 	for (i = 9; (i > 0) && !((val >> i) & 1); --i);
 	return i;
-*/
+#endif
 }
 
 void sceGuTexImage(int mipmap, int width, int height, int tbw, const void* tbp)


### PR DESCRIPTION
Clang refuses to assemble the `asm` macro, stating the instruction is "unavailable with your current feature set", and im not sure why, ive tried enabling a bunch of features, and nothing seems to make it happy. So i enabled the non-accelerated codepath on clang, which makes it compile, and allows most of gu (at least all thats needed for a cube sample) to be compiled using the LLVM/Clang 16 shipped with the Zig compiler