### PR TITLE
Add sceIoDevctl structure to get free disk space

### DIFF
--- a/src/user/pspiofilemgr.h
+++ b/src/user/pspiofilemgr.h
@@ -17,6 +17,7 @@
 #include <pspiofilemgr_fcntl.h>
 #include <pspiofilemgr_stat.h>
 #include <pspiofilemgr_dirent.h>
+#include <pspiofilemgr_devctl.h>
 
 /** @defgroup FileIO File IO Library 
  *  This module contains the imports for the kernel's IO routines.

--- a/src/user/pspiofilemgr_devctl.h
+++ b/src/user/pspiofilemgr_devctl.h
@@ -1,0 +1,36 @@
+/*
+ * PSP Software Development Kit - https://github.com/pspdev
+ * -----------------------------------------------------------------------
+ * Licensed under the BSD license, see LICENSE in PSPSDK root for details.
+ *
+ * pspiofilemgr_devctl.h - File attributes and directory entries.
+ *
+ */
+
+#ifndef PSPIOFILEMGR_DEVCTL_H
+#define PSPIOFILEMGR_DEVCTL_H
+
+#include <psptypes.h>
+
+/* This sceIoDevctl command gets the device capacity. */
+#define SCE_PR_GETDEV 0x02425818
+
+/* This structure stores the device capacity using SCE_PR_GETDEV in sceIoDevctl */
+typedef struct SceDevInf {
+    /* max logical cluster x unit */
+    uint32_t maxClusters;
+    /* number of empty clusters */
+    uint32_t freeClusters;
+    /* cluster of empty logical block */
+    uint32_t maxSectors;
+    /* bytes x logical sector */
+    int sectorSize;
+    /* sector x cluster */
+    int sectorCount;
+} SceDevInf;
+
+typedef struct SceDevctlCmd {
+    SceDevInf *dev_inf;
+} SceDevctlCmd;
+
+#endif /* PSPIOFILEMGR_DEVCTL_H */


### PR DESCRIPTION
This PR adds the `SceDevInf` structure for `sceIoDevctl()`

Sample code:

```c
    SceDevInf inf;
    SceDevctlCmd cmd;
    uint64_t freeSize = 0;

    cmd.dev_inf = &inf;
    sceIoDevctl("ms0:", SCE_PR_GETDEV, &cmd, sizeof(SceDevctlCmd), NULL, 0);
    freeSize = inf.freeClusters * inf.sectorCount * inf.sectorSize;
```

Note: based on https://github.com/PSP-Archive/ARK-4/blob/c30e43944521ac40af5a93209122e00e59281848/extras/menus/arkMenu/src/common.cpp#L544
