### PR TITLE
include psptypes.h in psprtc.h

### DIFF
--- a/src/rtc/psprtc.h
+++ b/src/rtc/psprtc.h
@@ -14,6 +14,7 @@
 #define __PSPRTC_H__
 
 #include <time.h>
+#include <psptypes.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes #155

I tested this by adding `#include <psprtc.h>` at the top of `main.c` for the `debug/kprintf` sample. With this fix it compiles, without this fix it does not.