### PR TITLE
Fixes and improvements `libcglue`

### DIFF
--- a/src/libcglue/Makefile.am
+++ b/src/libcglue/Makefile.am
@@ -24,8 +24,8 @@ ERRNO_OBJS = __set_errno.o
 FDMAN_OBJS = __descriptor_data_pool.o __descriptormap.o __fdman_init.o __fdman_get_new_descriptor.o __fdman_get_dup_descriptor.o \
 	__fdman_release_descriptor.o
 
-GLUE_OBJS = __dummy_passwd.o __fill_stat.o __psp_heap_blockid.o __psp_free_heap.o _fork.o _wait.o _open.o _close.o _read.o \
-	_write.o _fstat.o _stat.o lstat.o access.o _fcntl.o  _lseek.o chdir.o mkdir.o rmdir.o getdents.o _seekdir.o _link.o _unlink.o \
+GLUE_OBJS = __dummy_passwd.o __psp_heap_blockid.o __psp_free_heap.o _fork.o _wait.o _open.o _close.o _read.o \
+	_write.o _fstat.o _stat.o lstat.o access.o _fcntl.o  _lseek.o chdir.o mkdir.o rmdir.o getdents.o _link.o _unlink.o \
 	_rename.o _getpid.o _kill.o _sbrk.o _gettimeofday.o _times.o ftime.o clock_getres.o clock_gettime.o clock_settime.o \
 	_isatty.o symlink.o truncate.o chmod.o fchmod.o fchmodat.o pathconf.o readlink.o utime.o fchown.o getentropy.o getpwuid.o \
 	fsync.o getpwnam.o getuid.o geteuid.o basename.o statvfs.o


### PR DESCRIPTION
## Description
We had defined in `libcglue` the function `_seekdir`, however, that function was defined in newlib
https://github.com/bminor/newlib/blob/master/newlib/libc/posix/telldir.c#L116-L166

So taking a look at the implementation we see how it is actually using `lseek` for folders, so basically I have modified the `lseek` function to support folders calling a private function `_lseekDir` which is basically the same approach that initially the function `_seekdir` defined in `libcglue` was trying to do.

Additionally, some other legacy conditions have been wiped out and improved.

Cheers