### PR TITLE
Update psputility_savedata.h

### DIFF
--- a/src/utility/psputility_savedata.h
+++ b/src/utility/psputility_savedata.h
@@ -112,9 +112,9 @@ typedef struct PspUtilitySavedataSizeInfo {
 typedef struct SceUtilitySavedataIdListEntry
 {
 	int st_mode;
-	ScePspDateTime st_ctime;
-	ScePspDateTime st_atime;
-	ScePspDateTime st_mtime;
+	ScePspDateTime sce_st_ctime;
+	ScePspDateTime sce_st_atime;
+	ScePspDateTime sce_st_mtime;
 	char name[20];
 
 } SceUtilitySavedataIdListEntry;
@@ -132,9 +132,9 @@ typedef struct SceUtilitySavedataFileListEntry
 	int st_mode;
 	uint32_t st_unk0;
 	uint64_t st_size;
-	ScePspDateTime st_ctime;
-	ScePspDateTime st_atime;
-	ScePspDateTime st_mtime;
+	ScePspDateTime sce_st_ctime;
+	ScePspDateTime sce_st_atime;
+	ScePspDateTime sce_st_mtime;
 	char name[16];
 
 } SceUtilitySavedataFileListEntry;


### PR DESCRIPTION
Fix name collision and match names from `pspiofilemgr_stat.h`

Depending on the `#includes`, you could get an error when using `psputility_savedata.h`:

```
/usr/local/pspdev/psp/sdk/include/psputility_savedata.h:115:24: error: expected ‘:’, ‘,’, ‘;’, ‘}’ or ‘__attribute__’ before ‘.’ token
  115 |         ScePspDateTime st_ctime;
      |                        ^~~~~~~~
/usr/local/pspdev/psp/sdk/include/psputility_savedata.h:135:24: error: expected ‘:’, ‘,’, ‘;’, ‘}’ or ‘__attribute__’ before ‘.’ token
  135 |         ScePspDateTime st_ctime;
      |                        ^~~~~~~~
```