### PR TITLE
CMake: Allow setting app version in PARAM.SFO

### DIFF
--- a/src/base/CreatePBP.cmake
+++ b/src/base/CreatePBP.cmake
@@ -16,12 +16,20 @@ macro(create_pbp_file)
     ICON_PATH       # optional, absolute path to .png file, 144x82
     BACKGROUND_PATH # optional, absolute path to .png file, 480x272
     PREVIEW_PATH    # optional, absolute path to .png file, 480x272
+    VERSION         # optional, adds version information to PARAM.SFO
     )
   set(options
     BUILD_PRX # optional, generates and uses PRX file instead of ELF in EBOOT.PBP
     ENC_PRX   # optional, replaces PRX file with encrypted version.
     )
   cmake_parse_arguments("ARG" "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  # set mksfoex parameter if VERSION has been defined
+  if (DEFINED ARG_VERSION)
+    set(ARG_VERSION "-s APP_VER=${ARG_VERSION}")
+  else()
+    set(ARG_VERSION "")
+  endif()
 
   # As pack-pbp takes undefined arguments in form of "NULL" string,
   # set each undefined macro variable to such value:
@@ -117,7 +125,7 @@ macro(create_pbp_file)
   add_custom_command(
     TARGET ${ARG_TARGET}
     POST_BUILD COMMAND
-    "${PSPDEV}/bin/mksfoex" "-d" "MEMSIZE=1" "${ARG_TITLE}" "PARAM.SFO"
+    "${PSPDEV}/bin/mksfoex" "-d" "MEMSIZE=1" "${ARG_VERSION}" "${ARG_TITLE}" "PARAM.SFO"
     COMMENT "Calling mksfoex"
     )
 


### PR DESCRIPTION
this PR updates `CreatePBP.cmake` so you can set up a `VERSION` parameter in your `CMakeLists.txt` and get the `PARAM.SFO` generated with the correct `APP_VER` value.

When you generate the EBOOT.PBP, in the XMB you can select "information" and you'll see the Version details.

Example how to use it:
```
create_pbp_file(
  TARGET ${PROJECT_NAME}
  ICON_PATH ${CMAKE_SOURCE_DIR}/ICON0.PNG
  BACKGROUND_PATH NULL
  PREVIEW_PATH NULL
  TITLE "Apollo Save Tool"
  VERSION 01.30
)
```