### PR TITLE
allow pspsdk to be built without pthread-embedded

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,8 @@ AC_CHECK_LIB([z], [compress])
 AC_C_CONST
 AC_C_BIGENDIAN
 
+AC_ARG_WITH(pthread,  [ --with-pthread  build with pthread support], [], [with_pthread=yes])
+
 # Checks for library functions.
 AC_FUNC_MEMCMP
 AC_CHECK_FUNCS([getcwd strchr])
@@ -72,6 +74,10 @@ AC_SUBST(PSPSDK_LIBDIR)
 # CFLAGS and CXXFLAGS used to build pspsdk libraries.
 PSPSDK_CFLAGS="$CFLAGS -mno-gpopt -Wall"
 PSPSDK_CXXFLAGS="$PSPSDK_CFLAGS -fno-exceptions -fno-rtti"
+if test "$with_pthread" = no ; then
+	PSPSDK_CFLAGS="$PSPSDK_CFLAGS -DPSP_WITHOUT_PTHREAD"
+fi
+
 AC_SUBST(PSPSDK_CFLAGS)
 AC_SUBST(PSPSDK_CXXFLAGS)
 

--- a/src/libcglue/init.c
+++ b/src/libcglue/init.c
@@ -29,7 +29,7 @@ void __deinit_mutex();
 
 extern int sce_newlib_nocreate_thread_in_start __attribute__((weak));
 
-#ifdef F___libpthreadglue_init
+#if defined(F___libpthreadglue_init) && !defined(PSP_WITHOUT_PTHREAD)
 /* Note: This function is being called from __libcglue_init.
 * It is a weak function because can be override by user program
 */
@@ -38,6 +38,8 @@ void __libpthreadglue_init()
 {
     pthread_init();
 }
+#elif defined(PSP_WITHOUT_PTHREAD)
+#define __libpthreadglue_init() do{}while(0)
 #else
 void __libpthreadglue_init();
 #endif

--- a/src/libpthreadglue/osal.c
+++ b/src/libpthreadglue/osal.c
@@ -9,6 +9,7 @@
  *
  */
 
+#ifndef PSP_WITHOUT_PTHREAD
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -786,3 +787,5 @@ int pte_osAtomicIncrement(int *pdest)
   return val;
 }
 #endif
+
+#endif /* PSP_WITHOUT_PTHREAD */

--- a/src/libpthreadglue/tls-helper.c
+++ b/src/libpthreadglue/tls-helper.c
@@ -9,6 +9,7 @@
  *
  */
 
+#ifndef PSP_WITHOUT_PTHREAD
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -252,3 +253,5 @@ pte_osResult pte_osTlsFree(unsigned int index)
   return pteTlsFree(index);
 }
 #endif
+
+#endif /* PSP_WITHOUT_PTHREAD */


### PR DESCRIPTION
just like it used to work until 8a0ab6b.

closes #183