### PR TITLE
Add F_SETFD cmd to _fcntl function

### DIFF
--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -443,6 +443,19 @@ int _fcntl(int fd, int cmd, ...)
 			return 0;
 			break;
 		}
+		case F_SETFD:
+		{
+			int newfl;
+			va_list args;
+	
+			va_start (args, cmd);         /* Initialize the argument list. */
+			newfl =  va_arg(args, int);
+			va_end (args);                /* Clean up. */
+
+			__descriptormap[fd]->flags = newfl;
+			return 0;
+			break;
+		}
 	}
 
 	errno = EBADF;


### PR DESCRIPTION
## Description

This change fixes the directory iterator.

The reason why it started to fail recently is that we are every time more and more POSIX. 
After the latest changes on `newlib` and `pspsdk`, how we now support more POSIX functions the libcpp libraries are trying a new way/path (probably more optimal) to do such kind of operations.
Then this went for a path with an existing issue that we hadn't faced before.

Here you have the output using PPSSPP with the dummy project [directory-iterator-psp](https://github.com/sharkwouter/directory-iterator-psp)

<img width="1072" alt="Screenshot 2024-04-01 at 22 52 32" src="https://github.com/pspdev/pspsdk/assets/10010409/016ff04d-8c86-4c5f-a15e-26764ecc5a08">


Cheers.