### PR TITLE
Fix pthread issues

### DIFF
--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -758,7 +758,7 @@ clock_t _times(struct tms *buffer)
 	if (buffer != NULL) {
 		buffer->tms_utime  = clk;
 		buffer->tms_stime  = 0;
-		buffer->tms_cutime = clk;
+		buffer->tms_cutime = 0;
 		buffer->tms_cstime = 0;
 	}
 

--- a/src/libpthreadglue/osal.c
+++ b/src/libpthreadglue/osal.c
@@ -339,8 +339,9 @@ pte_osResult pte_osThreadWaitForEnd(pte_osThreadHandle threadHandle)
 
   while (1) {
     SceKernelThreadRunStatus info;
-
     /* Poll task to see if it has ended */
+    
+    /* Prepare info before be use in sceKernelReferThreadRunStatus */
     memset(&info,0,sizeof(info));
     info.size = sizeof(info);
     sceKernelReferThreadRunStatus(threadHandle, &info);      
@@ -355,6 +356,9 @@ pte_osResult pte_osThreadWaitForEnd(pte_osThreadHandle threadHandle)
       if (pThreadData != NULL) {
         SceUID osResult;
 
+        /* Prepare semInfo before be use in sceKernelReferSemaStatus */
+        memset(&semInfo, 0, sizeof(semInfo));
+        semInfo.size = sizeof(semInfo);
         osResult = sceKernelReferSemaStatus(pThreadData->cancelSem, &semInfo);
         if (osResult == SCE_KERNEL_ERROR_OK) {
           if (semInfo.currentCount > 0) {
@@ -390,7 +394,9 @@ int pte_osThreadGetPriority(pte_osThreadHandle threadHandle)
 {
   SceKernelThreadInfo thinfo;
 
-  thinfo.size = sizeof(SceKernelThreadInfo);
+  /* Prepare info before be use in sceKernelReferThreadRunStatus */
+  memset(&thinfo,0,sizeof(thinfo));
+  thinfo.size = sizeof(thinfo);
   sceKernelReferThreadStatus(threadHandle, &thinfo);
 
   return thinfo.currentPriority;
@@ -435,6 +441,9 @@ pte_osResult pte_osThreadCheckCancel(pte_osThreadHandle threadHandle)
 
   pThreadData = __getThreadData(threadHandle);
   if (pThreadData != NULL) {
+    /* Prepare semInfo before be use in sceKernelReferSemaStatus */
+    memset(&semInfo, 0, sizeof(semInfo));
+    semInfo.size = sizeof(semInfo);
     osResult = sceKernelReferSemaStatus(pThreadData->cancelSem, &semInfo);
 
     if (osResult == SCE_KERNEL_ERROR_OK) {
@@ -687,6 +696,9 @@ pte_osResult pte_osSemaphoreCancellablePend(pte_osSemaphoreHandle semHandle, uns
       if (pThreadData != NULL) {
         SceUID osResult;
 
+        /* Prepare semInfo before be use in sceKernelReferSemaStatus */
+        memset(&semInfo, 0, sizeof(semInfo));
+        semInfo.size = sizeof(semInfo);
         osResult = sceKernelReferSemaStatus(pThreadData->cancelSem, &semInfo);
         if (osResult == SCE_KERNEL_ERROR_OK) {
           if (semInfo.currentCount > 0) {

--- a/src/libpthreadglue/tls-helper.c
+++ b/src/libpthreadglue/tls-helper.c
@@ -158,7 +158,9 @@ void *__getTlsStructFromThread(SceUID thid)
   int numMatches;
 
 
-  thinfo.size = sizeof(SceKernelThreadInfo);
+  /* Prepare thinfo before be use in sceKernelReferThreadRunStatus */
+  memset(&thinfo,0,sizeof(thinfo));
+  thinfo.size = sizeof(thinfo);
   sceKernelReferThreadStatus(thid, &thinfo);
   numMatches = sscanf(thinfo.name,"pthread%04d__%x", &thrNum, &ptr);
 

--- a/src/prof/prof.c
+++ b/src/prof/prof.c
@@ -130,6 +130,7 @@ static void initialize()
         int thid = sceKernelGetThreadId();
         
         SceKernelThreadInfo info;
+        memset(&info, 0, sizeof(info));
         info.size = sizeof(info);
         int ret = sceKernelReferThreadStatus(thid, &info);
         


### PR DESCRIPTION
Thanks to these changes I'm able to pass all the pthreadembedded test suites.

The majority of the changes are related to:
- Wrong implementation of `_times` in glue.
- Wrong priorities in creating/modifying threads
- Wrong timeouts
- Before calling `sceKernelReferThreadRunStatus` we must set `size` field with the proper value.
- Before calling `sceKernelReferSemaStatus` we must set `size` field with the proper value.
- Other minor changes

As a bonus, probably 255 is the max of threads we can create, however, every time we create a thread it tries to allocate memory from the available one, however, how the current libcglue implementation takes almost the whole space for the heap, the limit of threads is drastically decreased to 20 more or less.
If you are required to create several threads, you should use macro `PSP_HEAP_THRESHOLD_SIZE_KB` to increase the threshold we let for creating threads.

Here you have the output of the unit tests.
```
Running tests...
=========================
   Test iteration #0
=========================
Reuse test #1
Create test #1
Create test #2
Create test #3
Join test #0
Join test #1
Join test #2
Join test #3
Join test #4
Kill test #1
Exit test #1
Exit test #2
Exit test #3
Priority test #1
Priority test #2
Valid test #1
Valid test #2
Self test #1
Self test #2
Equal test #1
Count test #1
Delay test #1
Delay test #2
Once test #1
Once test #2
Once test #3
Once test #4
TSD test #1
TSD test #2
Detach test #1
Mutex test #1
Mutex test #1(e)
Mutex test #1(n)
Mutex test #1(r)
Mutex test #2
Mutex test #2(e)
Mutex test #2(r)
Mutex test #3
Mutex test #3(e)
Mutex test #3(r)
Mutex test #4
Mutex test #5
Mutex test #6
Mutex test #6e
Mutex test #6es
Mutex test #6n
Mutex test #6r
Mutex test #6rs
Mutex test #6s
Mutex test #7
Mutex test #7e
Mutex test #7n
Mutex test #7r
Mutex test #8
Mutex test #8e
Mutex test #8n
Mutex test #8r
Semaphore test #1
Semaphore test #2
Semaphore test #3
Semaphore test #4
Semaphore test #4t
Semaphore test #5
Semaphore test #6
Condvar test #1
Condvar test #1-1
Condvar test #1-2
Condvar test #2
Condvar test #2-1
Condvar test #3
Condvar test #3-1
Condvar test #3-2
Condvar test #3-3
Condvar test #4
Condvar test #5
Condvar test #6
Condvar test #7
Condvar test #8
Condvar test #9
Barrier test #1
Barrier test #2
Barrier test #3
Barrier test #4
Barrier test #5
Spin test #1
Spin test #2
Spin test #3
Spin test #4
spin test #4 not run - it requires multiple CPUs.
Rwlock test #1
Rwlock test #2
Rwlock test #2t
Rwlock test #3
Rwlock test #3t
Rwlock test #4
Rwlock test #4t
Rwlock test #5
Rwlock test #5t
Rwlock test #6
Rwlock test #6t
Rwlock test #6t2
Rwlock test #7
Rwlock test #8
Cancel test #1
Cancel test #2
Cancel test #3
Test not run - async cancellation not supported
Cancel test #4
Cancel test #5
Test not run - async cancellation not supported
Cancel test #6a
Test not run - async cancellation not supported
Cancel test #6d
Cleanup test #0
Test not run - async cancellation not supported
Cleanup test #1
Test not run - async cancellation not supported
Cleanup test #2
Test not run - async cancellation not supported
Cleanup test #3
Test not run - async cancellation not supported
Exception test #1
Test N/A for this compiler environment.
Exception test #3
Test N/A for this compiler environment.
Benchmark test #1
=============================================================================
Lock plus unlock on an unlocked mutex.
100000 iterations
Test                                              Total(msec)   average(usec)
Dummy call x 2                                              8           0.080
Dummy call -> Interlocked with cond x 2                    76           0.760
InterlockedOp x 2                                          22           0.220
Simple Critical Section                                  1083          10.830
.............................................................................
PTHREAD_MUTEX_DEFAULT                                      90           0.900
PTHREAD_MUTEX_NORMAL                                       90           0.900
PTHREAD_MUTEX_ERRORCHECK                                 1777          17.770
PTHREAD_MUTEX_RECURSIVE                                  1794          17.940
=============================================================================
Benchmark test #2
=============================================================================
Lock plus unlock on a locked mutex.
10000 iterations, four locks/unlocks per iteration.
Test                                              Total(msec)   average(usec)
PTHREAD_MUTEX_DEFAULT                                     909          22.725
PTHREAD_MUTEX_NORMAL                                      909          22.725
PTHREAD_MUTEX_ERRORCHECK                                 1539          38.475
PTHREAD_MUTEX_RECURSIVE                                  1533          38.325
=============================================================================
Benchmark test #3
=============================================================================
Trylock on a locked mutex.
100000 iterations.
Test                                              Total(msec)   average(usec)
.............................................................................
PTHREAD_MUTEX_DEFAULT (W9x,WNT)                            52           0.520
PTHREAD_MUTEX_NORMAL (W9x,WNT)                             53           0.530
PTHREAD_MUTEX_ERRORCHECK (W9x,WNT)                         52           0.520
PTHREAD_MUTEX_RECURSIVE (W9x,WNT)                        1654          16.540
=============================================================================
Benchmark test #4
=============================================================================
Trylock plus unlock on an unlocked mutex.
100000 iterations.
Test                                              Total(msec)   average(usec)
PTHREAD_MUTEX_DEFAULT                                      89           0.890
PTHREAD_MUTEX_NORMAL                                       89           0.890
PTHREAD_MUTEX_ERRORCHECK                                 1762          17.620
PTHREAD_MUTEX_RECURSIVE                                  1785          17.850
=============================================================================
Stress test #1
=========================
   Test iteration #1
=========================
Skipping Reuse test #1 (required to run first on first iteration only)
Create test #1
Create test #2
Create test #3
Join test #0
Join test #1
Join test #2
Join test #3
Join test #4
Kill test #1
Exit test #1
Exit test #2
Exit test #3
Priority test #1
Priority test #2
Valid test #1
Valid test #2
Self test #1
Self test #2
Equal test #1
Count test #1
Delay test #1
Delay test #2
Once test #1
Once test #2
Once test #3
Once test #4
TSD test #1
TSD test #2
Detach test #1
Mutex test #1
Mutex test #1(e)
Mutex test #1(n)
Mutex test #1(r)
Mutex test #2
Mutex test #2(e)
Mutex test #2(r)
Mutex test #3
Mutex test #3(e)
Mutex test #3(r)
Mutex test #4
Mutex test #5
Mutex test #6
Mutex test #6e
Mutex test #6es
Mutex test #6n
Mutex test #6r
Mutex test #6rs
Mutex test #6s
Mutex test #7
Mutex test #7e
Mutex test #7n
Mutex test #7r
Mutex test #8
Mutex test #8e
Mutex test #8n
Mutex test #8r
Semaphore test #1
Semaphore test #2
Semaphore test #3
Semaphore test #4
Semaphore test #4t
Semaphore test #5
Semaphore test #6
Condvar test #1
Condvar test #1-1
Condvar test #1-2
Condvar test #2
Condvar test #2-1
Condvar test #3
Condvar test #3-1
Condvar test #3-2
Condvar test #3-3
Condvar test #4
Condvar test #5
Condvar test #6
Condvar test #7
Condvar test #8
Condvar test #9
Barrier test #1
Barrier test #2
Barrier test #3
Barrier test #4
Barrier test #5
Spin test #1
Spin test #2
Spin test #3
Spin test #4
spin test #4 not run - it requires multiple CPUs.
Rwlock test #1
Rwlock test #2
Rwlock test #2t
Rwlock test #3
Rwlock test #3t
Rwlock test #4
Rwlock test #4t
Rwlock test #5
Rwlock test #5t
Rwlock test #6
Rwlock test #6t
Rwlock test #6t2
Rwlock test #7
Rwlock test #8
Cancel test #1
Cancel test #2
Cancel test #3
Test not run - async cancellation not supported
Cancel test #4
Cancel test #5
Test not run - async cancellation not supported
Cancel test #6a
Test not run - async cancellation not supported
Cancel test #6d
Cleanup test #0
Test not run - async cancellation not supported
Cleanup test #1
Test not run - async cancellation not supported
Cleanup test #2
Test not run - async cancellation not supported
Cleanup test #3
Test not run - async cancellation not supported
Exception test #1
Test N/A for this compiler environment.
Exception test #3
Test N/A for this compiler environment.
Benchmark test #1
=============================================================================
Lock plus unlock on an unlocked mutex.
100000 iterations
Test                                              Total(msec)   average(usec)
Dummy call x 2                                              8           0.080
Dummy call -> Interlocked with cond x 2                    77           0.770
InterlockedOp x 2                                          23           0.230
Simple Critical Section                                  1076          10.760
.............................................................................
PTHREAD_MUTEX_DEFAULT                                      90           0.900
PTHREAD_MUTEX_NORMAL                                       90           0.900
PTHREAD_MUTEX_ERRORCHECK                                 1778          17.780
PTHREAD_MUTEX_RECURSIVE                                  1791          17.910
=============================================================================
Benchmark test #2
=============================================================================
Lock plus unlock on a locked mutex.
10000 iterations, four locks/unlocks per iteration.
Test                                              Total(msec)   average(usec)
PTHREAD_MUTEX_DEFAULT                                   21406         535.150
PTHREAD_MUTEX_NORMAL                                    21392         534.800
PTHREAD_MUTEX_ERRORCHECK                                22028         550.700
PTHREAD_MUTEX_RECURSIVE                                 22019         550.475
=============================================================================
Benchmark test #3
=============================================================================
Trylock on a locked mutex.
100000 iterations.
Test                                              Total(msec)   average(usec)
.............................................................................
PTHREAD_MUTEX_DEFAULT (W9x,WNT)                            52           0.520
PTHREAD_MUTEX_NORMAL (W9x,WNT)                             51           0.510
PTHREAD_MUTEX_ERRORCHECK (W9x,WNT)                         52           0.520
PTHREAD_MUTEX_RECURSIVE (W9x,WNT)                        1664          16.640
=============================================================================
Benchmark test #4
=============================================================================
Trylock plus unlock on an unlocked mutex.
100000 iterations.
Test                                              Total(msec)   average(usec)
PTHREAD_MUTEX_DEFAULT                                      90           0.900
PTHREAD_MUTEX_NORMAL                                       89           0.890
PTHREAD_MUTEX_ERRORCHECK                                 1763          17.630
PTHREAD_MUTEX_RECURSIVE                                  1785          17.850
=============================================================================
Stress test #1
Tests complete!
```

Cheers.