### PR TITLE
Fix lock api

### DIFF
--- a/src/libcglue/Makefile.am
+++ b/src/libcglue/Makefile.am
@@ -33,9 +33,27 @@ GLUE_OBJS = __dummy_passwd.o __psp_heap_blockid.o __psp_free_heap.o _fork.o _wai
 
 INIT_OBJS = __libpthreadglue_init.o __libcglue_init.o __libcglue_deinit.o _exit.o abort.o exit.o
 
-LOCK_OBJS = __retarget_lock_init.o __retarget_lock_acquire.o __retarget_lock_release.o __retarget_lock_try_acquire.o \
-	__retarget_lock_close.o __retarget_lock_init_recursive.o __retarget_lock_acquire_recursive.o __retarget_lock_release_recursive.o \
-	__retarget_lock_try_acquire_recursive.o __retarget_lock_close_recursive.o
+LOCK_OBJS = \
+	__lock___sfp_recursive_mutex.o \
+	__lock___atexit_recursive_mutex.o \
+	__lock___at_quick_exit_mutex.o \
+	__lock___malloc_recursive_mutex.o \
+	__lock___env_recursive_mutex.o \
+	__lock___tz_mutex.o \
+	__lock___dd_hash_mutex.o \
+	__lock___arc4random_mutex.o \
+	__retarget_lock_init.o \
+	__retarget_lock_init_recursive.o \
+	__retarget_lock_close.o \
+	__retarget_lock_close_recursive.o \
+	__retarget_lock_acquire.o \
+	__retarget_lock_acquire_recursive.o \
+	__retarget_lock_try_acquire.o \
+	__retarget_lock_try_acquire_recursive.o \
+	__retarget_lock_release.o \
+	__retarget_lock_release_recursive.o \
+	__locks_init.o \
+	__locks_deinit.o
 
 MUTEXMAN_OBJS = __sbrk_mutex.o __fdman_mutex.o __init_mutex.o __deinit_mutex.o
 

--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -1099,7 +1099,7 @@ int renameat(int olddirfd, const char *oldpath, int newdirfd, const char *newpat
 {
 	// TODO: Do better implementation following https://linux.die.net/man/2/renameat
 	// for now use the same as rename
-	return _rename(oldpath, newpath);
+	return rename(oldpath, newpath);
 }
 #endif /* F_renameat  */
 

--- a/src/user/pspthreadman.h
+++ b/src/user/pspthreadman.h
@@ -589,6 +589,17 @@ int sceKernelPollSema(SceUID semaid, int signal);
  */
 int sceKernelReferSemaStatus(SceUID semaid, SceKernelSemaInfo *info);
 
+/** Attribute for lightweight mutex. */
+enum PspLwMutexAttributes
+{
+	/** The wait thread is queued using FIFO. */
+	PSP_LW_MUTEX_ATTR_THFIFO = 0x0000U,
+	/** The wait thread is queued by thread priority . */
+	PSP_LW_MUTEX_ATTR_THPRI = 0x0100U,
+	/** A recursive lock is allowed by the thread that acquired the lightweight mutex */
+	PSP_LW_MUTEX_ATTR_RECURSIVE = 0x0200U
+};
+
 /** Struct as workarea for lightweight mutex */
 typedef struct {
     /** Count */
@@ -610,13 +621,13 @@ typedef struct {
  *
  * @param workarea - The pointer to the workarea
  * @param name - The name of the lightweight mutex
- * @param attr - 
+ * @param attr - The LwMutex attributes, zero or more of ::PspLwMutexAttributes.
  * @param initialCount - THe inital value of the mutex
  * @param optionsPTr - Other optioons for mutex
  *
  * @return 0 on success, otherwise one of ::PspKernelErrorCodes
  */
-int sceKernelCreateLwMutex(SceLwMutexWorkarea *workarea, const char *name, u32 attr, int initialCount, u32 *optionsPtr);
+int sceKernelCreateLwMutex(SceLwMutexWorkarea *workarea, const char *name, SceUInt32 attr, int initialCount, u32 *optionsPtr);
 
 /**
  * Delete a lightweight mutex


### PR DESCRIPTION
To have thread-safe operations for all the `newlib` operations we have been required to do several PR:

- [`newlib`](https://github.com/pspdev/newlib/pull/11)
- [`psptoolchain-ee`](https://github.com/pspdev/psptoolchain-allegrex/pull/32)
- [`pspsdk`](https://github.com/pspdev/pspsdk/pull/198)

This PR skips the usage of the dummy lock API, letting us implement the specific one in the `pspsdk/libcglue`

Cheers