### PR TITLE
Support for customized OUTPUT_NAME of a given target in create_pbp_file macro

### DIFF
--- a/src/base/CreatePBP.cmake
+++ b/src/base/CreatePBP.cmake
@@ -83,7 +83,7 @@ macro(create_pbp_file)
   add_custom_command(
     TARGET ${ARG_TARGET}
     POST_BUILD COMMAND
-    "$ENV{PSPDEV}/bin/psp-fixup-imports" "$<TARGET_FILE_DIR:${ARG_TARGET}>/${ARG_TARGET}"
+    "$ENV{PSPDEV}/bin/psp-fixup-imports" "$<TARGET_FILE:${ARG_TARGET}>"
     COMMENT "Calling psp-fixup-imports"
     )
 
@@ -91,8 +91,8 @@ macro(create_pbp_file)
     add_custom_command(
       TARGET ${ARG_TARGET}
       POST_BUILD COMMAND
-      "${PSPDEV}/bin/psp-prxgen" "$<TARGET_FILE_DIR:${ARG_TARGET}>/${ARG_TARGET}"
-      "$<TARGET_FILE_DIR:${ARG_TARGET}>/${ARG_TARGET}.prx"
+      "${PSPDEV}/bin/psp-prxgen" "$<TARGET_FILE:${ARG_TARGET}>"
+      "$<TARGET_FILE_DIR:${ARG_TARGET}>/$<TARGET_FILE_NAME:${ARG_TARGET}>.prx"
       COMMENT "Calling prxgen"
       )
 
@@ -100,8 +100,8 @@ macro(create_pbp_file)
       add_custom_command(
 	TARGET ${ARG_TARGET}
 	POST_BUILD COMMAND
-	"${PSPDEV}/bin/PrxEncrypter" "$<TARGET_FILE_DIR:${ARG_TARGET}>/${ARG_TARGET}.prx"
-	"$<TARGET_FILE_DIR:${ARG_TARGET}>/${ARG_TARGET}.prx"
+	"${PSPDEV}/bin/PrxEncrypter" "$<TARGET_FILE_DIR:${ARG_TARGET}>/$<TARGET_FILE_NAME:${ARG_TARGET}>.prx"
+	"$<TARGET_FILE_DIR:${ARG_TARGET}>/$<TARGET_FILE_NAME:${ARG_TARGET}>.prx"
 	COMMENT "Calling PrxEncrypter"
 	)
     else()
@@ -132,7 +132,7 @@ macro(create_pbp_file)
       TARGET ${ARG_TARGET}
       POST_BUILD COMMAND
       "${PSPDEV}/bin/pack-pbp" "EBOOT.PBP" "PARAM.SFO" "${ARG_ICON_PATH}" "NULL" "${ARG_PREVIEW_PATH}"
-      "${ARG_BACKGROUND_PATH}" "NULL" "$<TARGET_FILE_DIR:${ARG_TARGET}>/${ARG_TARGET}.prx" "NULL"
+      "${ARG_BACKGROUND_PATH}" "NULL" "$<TARGET_FILE_DIR:${ARG_TARGET}>/$<TARGET_FILE_NAME:${ARG_TARGET}>.prx" "NULL"
       COMMENT "Calling pack-pbp with PRX file"
       )
   else()
@@ -140,7 +140,7 @@ macro(create_pbp_file)
       TARGET ${ARG_TARGET}
       POST_BUILD COMMAND
       "${PSPDEV}/bin/pack-pbp" "EBOOT.PBP" "PARAM.SFO" "${ARG_ICON_PATH}" "NULL" "${ARG_PREVIEW_PATH}"
-      "${ARG_BACKGROUND_PATH}" "NULL" "$<TARGET_FILE_DIR:${ARG_TARGET}>/${ARG_TARGET}" "NULL"
+      "${ARG_BACKGROUND_PATH}" "NULL" "$<TARGET_FILE_DIR:${ARG_TARGET}>/$<TARGET_FILE_NAME:${ARG_TARGET}>" "NULL"
       COMMENT "Calling pack-pbp with ELF file"
       )
   endif()


### PR DESCRIPTION
Solves: https://github.com/pspdev/pspsdk/issues/196

@sharkwouter please review.