### PR TITLE
Adding Werror to compilation and solve warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,7 +72,7 @@ AC_SUBST(PSPSDK_INCLUDEDIR)
 AC_SUBST(PSPSDK_LIBDIR)
 
 # CFLAGS and CXXFLAGS used to build pspsdk libraries.
-PSPSDK_CFLAGS="$CFLAGS -mno-gpopt -Wall -D_PSP_FW_VERSION=600"
+PSPSDK_CFLAGS="$CFLAGS -mno-gpopt -Wall -Werror -D_PSP_FW_VERSION=600"
 PSPSDK_CXXFLAGS="$PSPSDK_CFLAGS -fno-exceptions -fno-rtti"
 if test "$with_pthread" = no ; then
 	PSPSDK_CFLAGS="$PSPSDK_CFLAGS -DPSP_WITHOUT_PTHREAD"

--- a/src/audio/pspaudiolib.c
+++ b/src/audio/pspaudiolib.c
@@ -30,13 +30,6 @@ void pspAudioSetVolume(int channel, int left, int right)
   AudioStatus[channel].volumeleft  = left;
 }
 
-void pspAudioChannelThreadCallback(int channel, void *buf, unsigned int reqn)
-{
-	pspAudioCallback_t callback;
-	callback=AudioStatus[channel].callback;
-}
-
-
 void pspAudioSetChannelCallback(int channel, pspAudioCallback_t callback, void *pdata)
 {
 	volatile psp_audio_channelinfo *pci = &AudioStatus[channel];

--- a/src/audio/pspaudiolib.h
+++ b/src/audio/pspaudiolib.h
@@ -41,7 +41,6 @@ void pspAudioEndPre();
 void pspAudioEnd();
 
 void pspAudioSetVolume(int channel, int left, int right);
-void pspAudioChannelThreadCallback(int channel, void *buf, unsigned int reqn);
 void pspAudioSetChannelCallback(int channel, pspAudioCallback_t callback, void *pdata);
 int  pspAudioOutBlocking(unsigned int channel, unsigned int vol1, unsigned int vol2, void *buf);
 

--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -152,7 +152,8 @@ int _open(const char *buf, int flags, int mode) {
 		return __set_errno(scefd);
 	}
 }
-
+#else
+int _open(const char *buf, int flags, int mode);
 #endif
 
 #ifdef F__close
@@ -339,8 +340,6 @@ int lstat(const char *filename, struct stat *buf)
 
 #ifdef F__fstat
 int _fstat(int fd, struct stat *buf) {
-	int ret;
-	SceOff oldpos;
 	if (!__IS_FD_VALID(fd)) {
 		errno = EBADF;
 		return -1;
@@ -1070,6 +1069,8 @@ int statvfs (const char *__path, struct statvfs *__buf)
 	__buf->f_bfree = inf.freeClusters;
 	__buf->f_bavail = inf.freeClusters;
 	__buf->f_namemax = MAXNAMLEN;
+
+	return 0;
 }
 #endif /* F_statvfs  */
 

--- a/src/libcglue/init.c
+++ b/src/libcglue/init.c
@@ -92,7 +92,8 @@ void __libcglue_deinit();
 #endif
 
 #ifdef F__exit
-void _exit(int status)
+__attribute__((__noreturn__))
+void _exit (int __status)
 {
 	__libcglue_deinit();
 
@@ -101,9 +102,12 @@ void _exit(int status)
 	} else {
 		sceKernelExitGame();
 	}
+	
+	while (1); // Avoid warning
 }
 #else
-void _exit(int status);
+__attribute__((__noreturn__))
+void _exit (int __status);
 #endif
 
 #ifdef F_abort

--- a/src/libcglue/lock.c
+++ b/src/libcglue/lock.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/lock.h>
 #include <pspthreadman.h>
 

--- a/src/libpthreadglue/tls-helper.c
+++ b/src/libpthreadglue/tls-helper.c
@@ -12,6 +12,7 @@
 #ifndef PSP_WITHOUT_PTHREAD
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <pspkerneltypes.h>
 #include <pspthreadman.h>


### PR DESCRIPTION
## Description
This PR enable `-Werror` by default when compiling.

Additionally, this PR is needed to be able to support GCC 14