### PR TITLE
Add build script and update build.txt

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -19,11 +19,7 @@ jobs:
 
     - name: Compile PSPSDK
       run: |
-        ./bootstrap
-        ./configure
-        make clean
-        make -j $(getconf _NPROCESSORS_ONLN)
-        make install
+        ./build-and-install.sh
     
     - name: Get short SHA
       id: slug

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -11,11 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/pspdev/psptoolchain:latest
     steps:
-    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
         apk add build-base autoconf automake zlib-dev bash git
+
+    - uses: actions/checkout@v4
 
     - name: Compile PSPSDK
       run: |

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        apk add build-base autoconf automake zlib-dev
+        apk add build-base autoconf automake zlib-dev bash git
 
     - name: Compile PSPSDK
       run: |

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Compile PSPSDK
       run: |
         chown -R $(id -nu):$(id -ng) .
-        export PSPDEV=$PWD/pspdev
+        export PSPDEV=/usr/local/pspdev
         export PATH=$PATH:$PSPDEV/bin
         ./build-and-install.sh
     

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -20,6 +20,9 @@ jobs:
 
     - name: Compile PSPSDK
       run: |
+        chown -R $(id -nu):$(id -ng) .
+        export PSPDEV=$PWD/pspdev
+        export PATH=$PATH:$PSPDEV/bin
         ./build-and-install.sh
     
     - name: Get short SHA

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,12 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-      
     - name: Login to Github registry
       uses: docker/login-action@v3
       with:
@@ -30,6 +24,7 @@ jobs:
     
     - uses: docker/build-push-action@v5
       with:
+        context: .
         push: true
         tags: ghcr.io/${{ github.repository }}:latest
         build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,26 +5,8 @@ FROM $BASE_DOCKER_IMAGE
 
 COPY . /src
 
-RUN apk add build-base autoconf automake zlib-dev
-RUN cd /src && \
-    ./bootstrap && \
-    ./configure && \
-    make -j $(getconf _NPROCESSORS_ONLN) clean && \
-    make -j $(getconf _NPROCESSORS_ONLN) && \
-    make -j $(getconf _NPROCESSORS_ONLN) install
-
-## gcc needs to include libcglue libpthreadglue libpsputility libpsprtc libpspnet_inet libpspnet_resolver libpspsdk libpspmodinfo libpspuser libpspkernel
-## from pspsdk to be able to build executables, because they are part of the standard libraries
-RUN ln -sf "$PSPDEV/psp/sdk/lib/libcglue.a" "$PSPDEV/psp/lib/libcglue.a" || { exit 1; }
-RUN ln -sf "$PSPDEV/psp/sdk/lib/libpthreadglue.a" "$PSPDEV/psp/lib/libpthreadglue.a" || { exit 1; }
-RUN ln -sf "$PSPDEV/psp/sdk/lib/libpsputility.a" "$PSPDEV/psp/lib/libpsputility.a" || { exit 1; }
-RUN ln -sf "$PSPDEV/psp/sdk/lib/libpsprtc.a" "$PSPDEV/psp/lib/libpsprtc.a" || { exit 1; }
-RUN ln -sf "$PSPDEV/psp/sdk/lib/libpspnet_inet.a" "$PSPDEV/psp/lib/libpspnet_inet.a" || { exit 1; }
-RUN ln -sf "$PSPDEV/psp/sdk/lib/libpspnet_resolver.a" "$PSPDEV/psp/lib/libpspnet_resolver.a" || { exit 1; }
-RUN ln -sf "$PSPDEV/psp/sdk/lib/libpspsdk.a" "$PSPDEV/psp/lib/libpspsdk.a" || { exit 1; }
-RUN ln -sf "$PSPDEV/psp/sdk/lib/libpspmodinfo.a" "$PSPDEV/psp/lib/libpspmodinfo.a" || { exit 1; }
-RUN ln -sf "$PSPDEV/psp/sdk/lib/libpspuser.a" "$PSPDEV/psp/lib/libpspuser.a" || { exit 1; }
-RUN ln -sf "$PSPDEV/psp/sdk/lib/libpspkernel.a" "$PSPDEV/psp/lib/libpspkernel.a" || { exit 1; }
+RUN apk add build-base autoconf automake zlib-dev bash git && \
+    /src/build-and-install.sh
 
 # Second stage
 FROM alpine:latest

--- a/build-and-install.sh
+++ b/build-and-install.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+## Fail script if an error happens
+set -e
+
+## Enter the pspsdk directory.
+cd "$(dirname "$0")" || { echo "ERROR: Could not enter the pspsdk directory."; exit 1; }
+
+## Make sure PSPDEV is set
+if [ -z "${PSPDEV}" ]; then
+    echo "The PSPDEV environment variable has not been set"
+    exit 1
+fi
+
+## Build pspsdk
+./bootstrap
+./configure
+make clean
+make -j $(getconf _NPROCESSORS_ONLN)
+
+## Install pspsdk
+make install
+
+## gcc needs to include libcglue libpthreadglue libpsputility libpsprtc libpspnet_inet libpspnet_resolver libpspsdk libpspmodinfo libpspuser libpspkernel
+## from pspsdk to be able to build executables, because they are part of the standard libraries
+cd "$PSPDEV/psp/lib"
+ln -sf "../sdk/lib/libcglue.a" "libcglue.a" || { exit 1; }
+ln -sf "../sdk/lib/libpthreadglue.a" "libpthreadglue.a" || { exit 1; }
+ln -sf "../sdk/lib/libpsputility.a" "libpsputility.a" || { exit 1; }
+ln -sf "../sdk/lib/libpsprtc.a" "libpsprtc.a" || { exit 1; }
+ln -sf "../sdk/lib/libpspnet_inet.a" "libpspnet_inet.a" || { exit 1; }
+ln -sf "../sdk/lib/libpspnet_resolver.a" "libpspnet_resolver.a" || { exit 1; }
+ln -sf "../sdk/lib/libpspsdk.a" "libpspsdk.a" || { exit 1; }
+ln -sf "../sdk/lib/libpspmodinfo.a" "libpspmodinfo.a" || { exit 1; }
+ln -sf "../sdk/lib/libpspuser.a" "libpspuser.a" || { exit 1; }
+ln -sf "../sdk/lib/libpspkernel.a" "libpspkernel.a" || { exit 1; }
+cd -
+
+## Store build information
+BUILD_FILE="${PSPDEV}/build.txt"
+if [[ -f "${BUILD_FILE}" ]]; then
+  sed -i='' '/^pspsdk /d' "${BUILD_FILE}"
+fi
+git log -1 --format="pspsdk %H %cs %s" >> "${BUILD_FILE}"


### PR DESCRIPTION
This also makes sure to create the links that the docker file was making for all builds. The link paths are relative, so they should be portable.