### PR TITLE
Do not add backup file with sed

### DIFF
--- a/build-and-install.sh
+++ b/build-and-install.sh
@@ -39,6 +39,6 @@ cd -
 ## Store build information
 BUILD_FILE="${PSPDEV}/build.txt"
 if [[ -f "${BUILD_FILE}" ]]; then
-  sed -i='' '/^pspsdk /d' "${BUILD_FILE}"
+  sed -i'' '/^pspsdk /d' "${BUILD_FILE}"
 fi
 git log -1 --format="pspsdk %H %cs %s" >> "${BUILD_FILE}"


### PR DESCRIPTION
At the moment it creates a build.txt= file. turns out busybox sed is a bit different.