### PR TITLE
Add gu in front of vram functions

### DIFF
--- a/src/gu/pspgu.h
+++ b/src/gu/pspgu.h
@@ -1516,7 +1516,7 @@ void guSwapBuffersCallback(GuSwapBuffersCallback callback);
   * 
   * @return A pointer to the buffer's relative to vram start (as required by sceGuDispBuffer, sceGuDrawBuffer, sceGuDepthBuffer and sceGuDrawBufferList)
 **/
-void* getStaticVramBuffer(unsigned int width, unsigned int height, unsigned int psm);
+void* guGetStaticVramBuffer(unsigned int width, unsigned int height, unsigned int psm);
 
 /**
   * Allocate a texture in vram
@@ -1535,7 +1535,7 @@ void* getStaticVramBuffer(unsigned int width, unsigned int height, unsigned int 
   * 
   * @return A pointer to the texture
 **/
-void* getStaticVramTexture(unsigned int width, unsigned int height, unsigned int psm);
+void* guGetStaticVramTexture(unsigned int width, unsigned int height, unsigned int psm);
 
 /**@}*/
 

--- a/src/gu/vram.c
+++ b/src/gu/vram.c
@@ -36,7 +36,7 @@ static unsigned int getMemorySize(unsigned int width, unsigned int height, unsig
 	}
 }
 
-void* getStaticVramBuffer(unsigned int width, unsigned int height, unsigned int psm)
+void* guGetStaticVramBuffer(unsigned int width, unsigned int height, unsigned int psm)
 {
 	unsigned int memSize = getMemorySize(width,height,psm);
 	void* result = (void*)staticOffset;
@@ -45,8 +45,8 @@ void* getStaticVramBuffer(unsigned int width, unsigned int height, unsigned int 
 	return result;
 }
 
-void* getStaticVramTexture(unsigned int width, unsigned int height, unsigned int psm)
+void* guGetStaticVramTexture(unsigned int width, unsigned int height, unsigned int psm)
 {
-	void* result = getStaticVramBuffer(width,height,psm);
+	void* result = guGetStaticVramBuffer(width,height,psm);
 	return (void*)(((unsigned int)result) + ((unsigned int)sceGeEdramGetAddr()));
 }

--- a/src/samples/gu/blend/blend.c
+++ b/src/samples/gu/blend/blend.c
@@ -91,9 +91,9 @@ int main(int argc, char* argv[])
 
 	// setup GU
 
-	void* fbp0 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* fbp1 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* zbp = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
+	void* fbp0 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* fbp1 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* zbp = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
 
 	sceGuInit();
 	sceGuStart(GU_DIRECT,list);

--- a/src/samples/gu/blit/blit.c
+++ b/src/samples/gu/blit/blit.c
@@ -130,9 +130,9 @@ int main(int argc, char* argv[])
 
 	// Setup GU
 
-	void* fbp0 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* fbp1 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* zbp = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
+	void* fbp0 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* fbp1 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* zbp = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
 
 	sceGuInit();
 

--- a/src/samples/gu/copy/copy.c
+++ b/src/samples/gu/copy/copy.c
@@ -44,9 +44,9 @@ int main(int argc, char* argv[])
 
 	// setup
 
-	void* fbp0 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* fbp1 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* zbp = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
+	void* fbp0 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* fbp1 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* zbp = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
 
 	pspDebugScreenInit();
 	sceGuInit();

--- a/src/samples/gu/cube/cube.c
+++ b/src/samples/gu/cube/cube.c
@@ -93,9 +93,9 @@ int main(int argc, char* argv[])
 
 	// setup GU
 
-	void* fbp0 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* fbp1 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* zbp = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
+	void* fbp0 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* fbp1 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* zbp = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
 
 	sceGuInit();
 

--- a/src/samples/gu/envmap/envmap.c
+++ b/src/samples/gu/envmap/envmap.c
@@ -69,9 +69,9 @@ int main(int argc, char* argv[])
 
 	// setup GU
 
-	void* fbp0 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* fbp1 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* zbp = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
+	void* fbp0 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* fbp1 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* zbp = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
 
 	pspDebugScreenInit();
 	sceGuInit();

--- a/src/samples/gu/lights/lights.c
+++ b/src/samples/gu/lights/lights.c
@@ -71,9 +71,9 @@ int main(int argc, char* argv[])
 
 	// setup GU
 
-	void* fbp0 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* fbp1 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* zbp = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
+	void* fbp0 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* fbp1 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* zbp = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
 
 	sceGuInit();
 

--- a/src/samples/gu/lines/lines.c
+++ b/src/samples/gu/lines/lines.c
@@ -87,9 +87,9 @@ int main(int argc, char* argv[])
 
 	// setup GU
 
-	void* fbp0 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* fbp1 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* zbp = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
+	void* fbp0 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* fbp1 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* zbp = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
 
 	sceGuInit();
 

--- a/src/samples/gu/logic/logic.c
+++ b/src/samples/gu/logic/logic.c
@@ -65,9 +65,9 @@ int main(int argc, char* argv[])
 
 	// setup GU
 
-	void* fbp0 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* fbp1 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* zbp = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
+	void* fbp0 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* fbp1 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* zbp = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
 
 	sceGuInit();
 

--- a/src/samples/gu/ortho/ortho.c
+++ b/src/samples/gu/ortho/ortho.c
@@ -47,9 +47,9 @@ int main(int argc, char* argv[])
  
 	// Setup GU
  
-	void* fbp0 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* fbp1 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* zbp = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
+	void* fbp0 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* fbp1 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* zbp = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
  
 	sceGuInit();
  

--- a/src/samples/gu/speed/speed.c
+++ b/src/samples/gu/speed/speed.c
@@ -270,9 +270,9 @@ int main(int argc, char* argv[])
 
 	// setup GU
 
-	void* fbp0 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* fbp1 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* zbp = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
+	void* fbp0 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* fbp1 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* zbp = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
 
 	pspDebugScreenInit();
 	sceGuInit();
@@ -304,7 +304,7 @@ int main(int argc, char* argv[])
 	// get vram buffer for vram -> vram blit
 
 	void* vram_buffer;
-	vram_buffer = getStaticVramTexture(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	vram_buffer = guGetStaticVramTexture(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
 
 	// flush caches to make sure no stray data remains
 

--- a/src/samples/gu/splinesurface/splinesurface.c
+++ b/src/samples/gu/splinesurface/splinesurface.c
@@ -208,9 +208,9 @@ int main(int argc, char* argv[])
 
 	// setup GU
 
-	void* fbp0 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* fbp1 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* zbp = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
+	void* fbp0 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* fbp1 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* zbp = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
 
 	sceGuInit();
 

--- a/src/samples/gu/sprite/sprite.c
+++ b/src/samples/gu/sprite/sprite.c
@@ -92,9 +92,9 @@ int main(int argc, char* argv[])
 
 	sceGuInit();
 
-	void* fbp0 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* fbp1 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* zbp = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
+	void* fbp0 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* fbp1 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* zbp = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
 
 	sceGuStart(GU_DIRECT,list);
 	sceGuDrawBuffer(GU_PSM_8888,fbp0,BUF_WIDTH);

--- a/src/samples/gu/vertex/vertex.c
+++ b/src/samples/gu/vertex/vertex.c
@@ -209,9 +209,9 @@ int main(int argc, char* argv[])
 
 	// setup GU
 
-	void* fbp0 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* fbp1 = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
-	void* zbp = getStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
+	void* fbp0 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* fbp1 = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_8888);
+	void* zbp = guGetStaticVramBuffer(BUF_WIDTH,SCR_HEIGHT,GU_PSM_4444);
 
 	pspDebugScreenInit();
 	sceGuInit();
@@ -244,12 +244,12 @@ int main(int argc, char* argv[])
 	int maxVertexSize = getVertexSize(GU_TEXTURE_32BITF|GU_COLOR_8888|GU_NORMAL_32BITF|GU_VERTEX_32BITF|GU_WEIGHT_32BITF|GU_WEIGHTS(8)|GU_VERTICES(8));
 	int batchSize = 1536; // max size = 608, 608 * 1536 = ~1MB, make sure you don't overrun vram limits if you change this
 	void* ramVertexBuffer = malloc(batchSize * maxVertexSize);
-	void* vramVertexBuffer = getStaticVramTexture(batchSize,maxVertexSize,GU_PSM_T8);
+	void* vramVertexBuffer = guGetStaticVramTexture(batchSize,maxVertexSize,GU_PSM_T8);
 
 	// allocate index buffers
 
 	void* ramIndexBuffer = malloc(batchSize * sizeof(unsigned short));
-	void* vramIndexBuffer = getStaticVramTexture(batchSize,sizeof(unsigned short),GU_PSM_T8);
+	void* vramIndexBuffer = guGetStaticVramTexture(batchSize,sizeof(unsigned short),GU_PSM_T8);
 
 	// run sample
 

--- a/src/samples/gu/zbufferfog/zbufferfog.c
+++ b/src/samples/gu/zbufferfog/zbufferfog.c
@@ -117,9 +117,9 @@ int main(int argc, char* argv[])
 
 	sceGuInit();
 
-	void* fbp0 = getStaticVramBuffer(BUFFER_WIDTH,SCREEN_HEIGHT,SCREEN_PSM); // drawbuffer 1, 512x272 (480x272 visible)
-	void* fbp1 = getStaticVramBuffer(BUFFER_WIDTH,SCREEN_HEIGHT,SCREEN_PSM); // drawbuffer 2
-	void* zbp = getStaticVramBuffer(BUFFER_WIDTH,SCREEN_HEIGHT,GU_PSM_4444); // zbuffer, always 16bit
+	void* fbp0 = guGetStaticVramBuffer(BUFFER_WIDTH,SCREEN_HEIGHT,SCREEN_PSM); // drawbuffer 1, 512x272 (480x272 visible)
+	void* fbp1 = guGetStaticVramBuffer(BUFFER_WIDTH,SCREEN_HEIGHT,SCREEN_PSM); // drawbuffer 2
+	void* zbp = guGetStaticVramBuffer(BUFFER_WIDTH,SCREEN_HEIGHT,GU_PSM_4444); // zbuffer, always 16bit
 
 	sceGuStart(GU_DIRECT,list);
 	sceGuDrawBuffer(SCREEN_PSM,fbp0,BUFFER_WIDTH);


### PR DESCRIPTION
This keeps the naming convention intact.