### PR TITLE
Add guGetDisplayState function to libgu

### DIFF
--- a/src/gu/pspgu.h
+++ b/src/gu/pspgu.h
@@ -1537,6 +1537,17 @@ void* guGetStaticVramBuffer(unsigned int width, unsigned int height, unsigned in
 **/
 void* guGetStaticVramTexture(unsigned int width, unsigned int height, unsigned int psm);
 
+/**
+  * Get state of display
+  *
+  * Available states are:
+  *   - GU_TRUE (1) - Display is turned on
+  *   - GU_FALSE (0) - Display is turned off
+  *
+  * @return State of the display
+**/
+int guGetDisplayState();
+
 /**@}*/
 
 #if defined(__cplusplus)

--- a/src/gu/sceGuDisplay.c
+++ b/src/gu/sceGuDisplay.c
@@ -21,3 +21,8 @@ int sceGuDisplay(int state)
 	gu_display_on = state;
 	return state;
 }
+
+int guGetDisplayState()
+{
+	return gu_display_on;
+}


### PR DESCRIPTION
This function allows users to get if the display is turned on in libgu. This can be useful for libraries like SDL, which want a way to check if it is before trying to display the on-screen keyboard or a native message dialog, since those do not work before libgu has been fully initialized.