### PR TITLE
Improve `exit` flow

### DIFF
--- a/src/libcglue/Makefile.am
+++ b/src/libcglue/Makefile.am
@@ -37,8 +37,6 @@ INIT_OBJS = \
 	__libcglue_init.o \
 	__gprof_cleanup.o \
 	__libcglue_deinit.o \
-	_exit.o \
-	abort.o \
 	exit.o
 
 LOCK_OBJS = \

--- a/src/libcglue/init.c
+++ b/src/libcglue/init.c
@@ -29,8 +29,6 @@ void __deinit_mutex();
 void __locks_init();
 void __locks_deinit();
 
-extern int sce_newlib_nocreate_thread_in_start __attribute__((weak));
-
 #ifdef F___gprof_cleanup
 /* Note: This function is being called from _exit and it is overrided when compiling with -pg */
 __attribute__((weak))
@@ -91,40 +89,13 @@ void __libcglue_init(int argc, char *argv[])
 __attribute__((weak))
 void __libcglue_deinit()
 {
+    __gprof_cleanup();
     __psp_free_heap();
 	__deinit_mutex();
 	__locks_deinit();
 }
 #else
 void __libcglue_deinit();
-#endif
-
-#ifdef F__exit
-__attribute__((__noreturn__))
-void _exit (int __status)
-{
-	__gprof_cleanup();
-	__libcglue_deinit();
-
-	if (&sce_newlib_nocreate_thread_in_start != NULL) {
-		sceKernelSelfStopUnloadModule(1, 0, NULL);
-	} else {
-		sceKernelExitGame();
-	}
-	
-	while (1); // Avoid warning
-}
-#else
-__attribute__((__noreturn__))
-void _exit (int __status);
-#endif
-
-#ifdef F_abort
-__attribute__((weak))
-void abort()
-{
-	_exit(1);
-}
 #endif
 
 #ifdef F_exit

--- a/src/startup/crt0_prx.c
+++ b/src/startup/crt0_prx.c
@@ -9,11 +9,14 @@
  *
  */
 
+#include <stdlib.h>
+#include <string.h>
+
 #include <pspkerneltypes.h>
 #include <pspmoduleinfo.h>
 #include <pspthreadman.h>
-#include <stdlib.h>
-#include <string.h>
+#include <psploadexec.h>
+#include <pspmodulemgr.h>
 
 /* The maximum number of arguments that can be passed to main(). */
 #define ARG_MAX 19
@@ -39,6 +42,7 @@ extern SceModuleInfo module_info __attribute__((weak));
 
 /* Allow to provide a libc init hook to be called before main */
 extern void __libcglue_init(int argc, char *argv[]);
+extern void __libcglue_deinit();
 extern void _init(void);
 extern void _fini(void);
 extern int main(int argc, char *argv[]);
@@ -78,14 +82,29 @@ void _main(SceSize args, void *argp)
 	/* Init can contain C++ constructors that require working threading */
 	_init();
 
-	/* Make sure _fini() is called when the program ends. */
-	atexit((void *) _fini);
-
 	/* Call main(). */
 	int res = main(argc, argv);
 
-	/* Return control to the operating system. */
+	/* Return control to the operating system. This will end calling `_exit`*/
 	exit(res);
+}
+
+__attribute__((__noreturn__))
+void _exit(int status)
+{
+	/* call global destructors*/
+	_fini();
+
+	// uninitialize libcglue
+	__libcglue_deinit();
+
+	if (&sce_newlib_nocreate_thread_in_start != NULL) {
+		sceKernelSelfStopUnloadModule(1, 0, NULL);
+	} else {
+		sceKernelExitGame();
+	}
+
+	while (1); // Avoid warning
 }
 
 int module_start(SceSize args, void *argp) __attribute__((alias("_start")));


### PR DESCRIPTION
## Description
This PR makes some improvements around the `exit` flow:
- Remove custom `abort` implementation as it is part of `newlib`
- Move `_exit` implementation from `libcglue` to `crt0` and `crt0_prx` even if it now is duplicated is cleaner to be there.
- The usage of `sce_newlib_nocreate_thread_in_start` now it is just on crt0 files.
- Remove the usage of `atexit` letting now the user to use that function without any additional issue.
- Other minor cleanup

Keep in mind that using directly `sceKernelExitGame` in your software is not recommended as it won't go through all the deinit process (`destructors` and `__libcglue_deinit`), so just use it unless you are not making usage of `newlib` at all, use instead always `exit` which is standard and it will call `sceKernelExitGame` at the end of the flow.

Cheers