### PR TITLE
Move `sceGeEdramSetSize` function to sceGe_driver

### DIFF
--- a/src/ge/Makefile.am
+++ b/src/ge/Makefile.am
@@ -10,9 +10,9 @@ CPPFLAGS = -I$(top_srcdir)/src/base -I$(top_srcdir)/src/kernel
 CFLAGS = @PSPSDK_CFLAGS@
 CCASFLAGS = $(CFLAGS)
 
-GE_OBJS = sceGe_user_0000.o sceGe_user_0001.o sceGe_user_0002.o sceGe_user_0003.o sceGe_user_0004.o sceGe_user_0005.o sceGe_user_0006.o sceGe_user_0007.o sceGe_user_0008.o sceGe_user_0009.o sceGe_user_0010.o sceGe_user_0011.o sceGe_user_0012.o sceGe_user_0013.o sceGe_user_0014.o sceGe_user_0015.o sceGe_user_0016.o sceGe_user_0017.o sceGe_user_0018.o sceGe_user_0019.o
+GE_OBJS = sceGe_user_0000.o sceGe_user_0001.o sceGe_user_0002.o sceGe_user_0003.o sceGe_user_0004.o sceGe_user_0005.o sceGe_user_0006.o sceGe_user_0007.o sceGe_user_0008.o sceGe_user_0009.o sceGe_user_0010.o sceGe_user_0011.o sceGe_user_0012.o sceGe_user_0013.o sceGe_user_0014.o sceGe_user_0015.o sceGe_user_0016.o sceGe_user_0017.o sceGe_user_0018.o
 
-GEDRIVER_OBJS = sceGe_driver_0000.o sceGe_driver_0001.o sceGe_driver_0002.o sceGe_driver_0003.o sceGe_driver_0004.o sceGe_driver_0005.o sceGe_driver_0006.o sceGe_driver_0007.o sceGe_driver_0008.o sceGe_driver_0009.o sceGe_driver_0010.o sceGe_driver_0011.o sceGe_driver_0012.o sceGe_driver_0013.o sceGe_driver_0014.o sceGe_driver_0015.o sceGe_driver_0016.o sceGe_driver_0017.o sceGe_driver_0018.o sceGe_driver_0019.o sceGe_driver_0020.o sceGe_driver_0021.o sceGe_driver_0022.o sceGe_driver_0023.o
+GEDRIVER_OBJS = sceGe_driver_0000.o sceGe_driver_0001.o sceGe_driver_0002.o sceGe_driver_0003.o sceGe_driver_0004.o sceGe_driver_0005.o sceGe_driver_0006.o sceGe_driver_0007.o sceGe_driver_0008.o sceGe_driver_0009.o sceGe_driver_0010.o sceGe_driver_0011.o sceGe_driver_0012.o sceGe_driver_0013.o sceGe_driver_0014.o sceGe_driver_0015.o sceGe_driver_0016.o sceGe_driver_0017.o sceGe_driver_0018.o sceGe_driver_0019.o sceGe_driver_0020.o sceGe_driver_0021.o sceGe_driver_0022.o sceGe_driver_0023.o sceGe_driver_0024.o
 
 libpspgeincludedir = @PSPSDK_INCLUDEDIR@
 libpspgeinclude_HEADERS = pspge.h

--- a/src/ge/sceGe_driver.S
+++ b/src/ge/sceGe_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceGe_driver_0000
-	IMPORT_START	"sceGe_driver",0x00010000
+	IMPORT_START	"sceGe_driver",0x00010011
 #endif
 #ifdef F_sceGe_driver_0001
 	IMPORT_FUNC	"sceGe_driver",0x71FCD1D6,sceGeInit
@@ -73,4 +73,7 @@
 #endif
 #ifdef F_sceGe_driver_0023
 	IMPORT_FUNC	"sceGe_driver",0x114E1745,sceGe_driver_114E1745
+#endif
+#ifdef F_sceGe_driver_0024
+	IMPORT_FUNC	"sceGe_driver",0x5BAA5439,sceGeEdramSetSize
 #endif

--- a/src/ge/sceGe_user.S
+++ b/src/ge/sceGe_user.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceGe_user_0000
-	IMPORT_START	"sceGe_user",0x40010000
+	IMPORT_START	"sceGe_user",0x40010011
 #endif
 #ifdef F_sceGe_user_0001
 	IMPORT_FUNC	"sceGe_user",0x1F6752AD,sceGeEdramGetSize
@@ -58,7 +58,4 @@
 #endif
 #ifdef F_sceGe_user_0018
 	IMPORT_FUNC	"sceGe_user",0x05DB22CE,sceGeUnsetCallback
-#endif
-#ifdef F_sceGe_user_0019
-	IMPORT_FUNC	"sceGe_user",0x5BAA5439,sceGeEdramSetSize
 #endif


### PR DESCRIPTION
PR is based on https://spenon-dev.github.io/PSPLibDoc/modules/ge.prx_sceGe_driver.html and https://github.com/uofw/uofw/blob/master/include/ge_kernel.h#L294

Also adjust the flags version of sceGe_driver and sceGe_user based on https://raw.githubusercontent.com/Spenon-dev/PSPLibDoc/main/PSPLibDoc/6.60/PSPLibDoc_6.60.xml

Hopefully could fix the issue #139