### PR TITLE
add gethostname implementation

### DIFF
--- a/src/libcglue/Makefile.am
+++ b/src/libcglue/Makefile.am
@@ -30,7 +30,7 @@ GLUE_OBJS = __dummy_passwd.o __psp_heap_blockid.o __psp_free_heap.o _fork.o _wai
 	_isatty.o symlink.o truncate.o chmod.o fchmod.o pathconf.o readlink.o utime.o fchown.o _getentropy.o getpwuid.o \
 	fsync.o getpwnam.o getuid.o geteuid.o basename.o statvfs.o \
 	openat.o renameat.o fchmodat.o fstatat.o mkdirat.o faccessat.o fchownat.o linkat.o readlinkat.o unlinkat.o \
-	realpath.o
+	realpath.o gethostname.o
 
 INIT_OBJS = \
 	__libpthreadglue_init.o \

--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -40,6 +40,7 @@
 #include <psputils.h>
 #include <pspsdk.h>
 #include <psprtc.h>
+#include <psputility.h>
 
 #include "fdman.h"
 
@@ -1214,3 +1215,17 @@ char *realpath(const char *path, char *resolved_path)
 	return resolved_path;
 }
 #endif /* F_realpath */
+
+#ifdef F_gethostname
+int gethostname (char *__name, size_t __len) {
+	char nickname[_SC_HOST_NAME_MAX];
+	memset(nickname, 0, _SC_HOST_NAME_MAX);
+
+	if (sceUtilityGetSystemParamString(PSP_SYSTEMPARAM_ID_STRING_NICKNAME, nickname, _SC_HOST_NAME_MAX) != PSP_SYSTEMPARAM_RETVAL_FAIL) {
+		strlcpy(__name, nickname, __len);
+		return 0;
+	}
+
+	return __set_errno(EINVAL);
+}
+#endif /* F_gethostname */


### PR DESCRIPTION
PSP doesn't really has a hostname, however it has a nickname that can serve the same function. Been playing around with PSP networking recently, and the lack of this function was a bit frustrating. This is a very simple replacement function that I came up with.