### PR TITLE
fix the link to the licence

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ bug.
 
 ## License
 
-PSPSDK is distributed under a [BSD-compatible license](LICENSE), with the exception of the
+PSPSDK is distributed under a [BSD-compatible license](https://github.com/pspdev/pspsdk/blob/master/LICENSE), with the exception of the
 files located in `tools/PrxEncrypter`. The files located in the `tools/PrxEncrypter`
 directory are subject to the terms of the GNU General Public License version 3.
 See the `LICENSE` files for more information.


### PR DESCRIPTION
The link is properly rendered on github but not in the external documentation (in https://pspdev.github.io/pspsdk/index.html).