### PR TITLE
Make analog stick values more readable in basic control sample

### DIFF
--- a/src/samples/controller/basic/main.c
+++ b/src/samples/controller/basic/main.c
@@ -74,8 +74,8 @@ int main(void)
 
 		sceCtrlReadBufferPositive(&pad, 1);
 
-		pspDebugScreenPrintf("Analog X = %d ", pad.Lx);
-		pspDebugScreenPrintf("Analog Y = %d \n", pad.Ly);
+		pspDebugScreenPrintf("Analog X = %3d ", pad.Lx);
+		pspDebugScreenPrintf("Analog Y = %3d \n", pad.Ly);
 
 		if (pad.Buttons != 0){
 			if (pad.Buttons & PSP_CTRL_SQUARE){


### PR DESCRIPTION
When the SceCtrlData.Lx value changes, the length of the value can change (from 1 character to 3 characters) so the string for Ly moves to the right by one or two characters.
The SceCtrlData.Lx and Ly are `unsigned char` so the value are between 0 (one character length) and 255 (3 characters length).
It's more readable by fixing the size for the value to 3 characters wide so the string to Ly does not move.