### PR TITLE
Fix: Use sce_stat->st_mode in io_to_posix_mode (glue.c) so it can also work for files stored in ISOs

### DIFF
--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -282,11 +282,11 @@ static time_t psp_to_posix_time(ScePspDateTime psp_time)
 static mode_t io_to_posix_mode(SceMode sceMode)
 {
         mode_t posixmode = 0;
-        if (sceMode & FIO_SO_IFREG) posixmode |= S_IFREG;
-        if (sceMode & FIO_SO_IFDIR) posixmode |= S_IFDIR;
-        if (sceMode & FIO_SO_IROTH) posixmode |= S_IRUSR|S_IRGRP|S_IROTH;
-        if (sceMode & FIO_SO_IWOTH) posixmode |= S_IWUSR|S_IWGRP|S_IWOTH;
-        if (sceMode & FIO_SO_IXOTH) posixmode |= S_IXUSR|S_IXGRP|S_IXOTH;
+        if (sceMode & FIO_S_IFREG) posixmode |= S_IFREG;
+        if (sceMode & FIO_S_IFDIR) posixmode |= S_IFDIR;
+        if (sceMode & FIO_S_IROTH) posixmode |= S_IRUSR|S_IRGRP|S_IROTH;
+        if (sceMode & FIO_S_IWOTH) posixmode |= S_IWUSR|S_IWGRP|S_IWOTH;
+        if (sceMode & FIO_S_IXOTH) posixmode |= S_IXUSR|S_IXGRP|S_IXOTH;
         return posixmode;
 }
 
@@ -295,7 +295,7 @@ static void __fill_stat(struct stat *stat, const SceIoStat *sce_stat)
 {
         stat->st_dev = 0;
         stat->st_ino = 0;
-        stat->st_mode = io_to_posix_mode(sce_stat->st_attr);
+        stat->st_mode = io_to_posix_mode(sce_stat->st_mode);
         stat->st_nlink = 0;
         stat->st_uid = 0;
         stat->st_gid = 0;


### PR DESCRIPTION
Created a PR as suggested by @sharkwouter 
Key messages that led to this change which fixed my issue:

1. Initial issue explained: https://discord.com/channels/479828644970364928/668436284800237694/1298297311235145878

2. Testing `sceIoGetstat` directly:
https://discord.com/channels/479828644970364928/668436284800237694/1298625671383351296
and
https://discord.com/channels/479828644970364928/668436284800237694/1298651722356494378

3. Found a forum post which suggests that using `st_attr` does not work when checking resources from a UMD, and `st_mode` should be used instead:
https://discord.com/channels/479828644970364928/668436284800237694/1298668881333846047

4. Issue is solved for me with this change from the PR, the SDL project works on both ISO and non-ISO context: 
https://discord.com/channels/479828644970364928/668436284800237694/1298700049257201705