### PR TITLE
Add support for setting the output directory to create_pbp_file macro

### DIFF
--- a/src/base/CreatePBP.cmake
+++ b/src/base/CreatePBP.cmake
@@ -34,15 +34,15 @@ macro(create_pbp_file)
   # set output directory to where the target is build if not set
   if (NOT DEFINED ARG_OUTPUT_DIR)
     set(ARG_OUTPUT_DIR $<TARGET_FILE_DIR:${ARG_TARGET}>)
-  endif()
-
-  # Make sure the output directory exists
-  if(NOT IS_DIRECTORY ${ARG_OUTPUT_DIR})
-    add_custom_command(
-      TARGET ${APP} POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E make_directory
-      ${ARG_OUTPUT_DIR}
-  )
+  else()
+    # Make sure the output directory exists
+    if(NOT IS_DIRECTORY ${ARG_OUTPUT_DIR})
+      add_custom_command(
+        TARGET ${APP} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+        ${ARG_OUTPUT_DIR}
+      )
+    endif()
   endif()
 
   # As pack-pbp takes undefined arguments in form of "NULL" string,

--- a/src/base/CreatePBP.cmake
+++ b/src/base/CreatePBP.cmake
@@ -18,6 +18,7 @@ macro(create_pbp_file)
     PREVIEW_PATH    # optional, absolute path to .png file, 480x272
     MUSIC_PATH      # optional, absolute path to .at3 file   
     VERSION         # optional, adds version information to PARAM.SFO
+    OUTPUT_DIR      # optional, set the output directory for the EBOOT.PBP
     )
   set(options
     BUILD_PRX # optional, generates and uses PRX file instead of ELF in EBOOT.PBP
@@ -28,6 +29,20 @@ macro(create_pbp_file)
   # set mksfoex parameter if VERSION was not defined
   if (NOT DEFINED ARG_VERSION)
     set(ARG_VERSION "")
+  endif()
+
+  # set output directory to where the target is build if not set
+  if (NOT DEFINED ARG_OUTPUT_DIR)
+    set(ARG_OUTPUT_DIR $<TARGET_FILE_DIR:${ARG_TARGET}>)
+  endif()
+
+  # Make sure the output directory exists
+  if(NOT IS_DIRECTORY ${ARG_OUTPUT_DIR})
+    add_custom_command(
+      TARGET ${APP} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+      ${ARG_OUTPUT_DIR}
+  )
   endif()
 
   # As pack-pbp takes undefined arguments in form of "NULL" string,
@@ -145,6 +160,13 @@ macro(create_pbp_file)
       COMMENT "Calling pack-pbp with ELF file"
       )
   endif()
+
+  add_custom_command(
+    TARGET ${APP} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E remove
+    ${ARG_OUTPUT_DIR}/PARAM.SFO
+    COMMENT "Cleaning up PARAM.SFO for target ${ARG_TARGET}"
+  )
 
   add_custom_command(
     TARGET ${ARG_TARGET}


### PR DESCRIPTION
This will allow us to make sure SDL can build with `-j8` for when building tests and it is also just nice to be able to set the output directory.