### PR TITLE
disable autoconf default compilation flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,10 @@ AC_PSPDEV_PATH
 AM_INIT_AUTOMAKE([1.14 foreign])
 AM_SILENT_RULES([yes])
 
+# Disable autoconf default compilation flags
+: ${CXXFLAGS=""}
+: ${CFLAGS=""}
+
 # Checks for programs.
 AC_PSPDEV_TOOLCHAIN
 AC_PROG_CC
@@ -73,7 +77,7 @@ AC_SUBST(PSPSDK_INCLUDEDIR)
 AC_SUBST(PSPSDK_LIBDIR)
 
 # CFLAGS and CXXFLAGS used to build pspsdk libraries.
-PSPSDK_CFLAGS="$CFLAGS -mno-gpopt -Wall -Werror -D_PSP_FW_VERSION=600"
+PSPSDK_CFLAGS="$CFLAGS -g -O2 -mno-gpopt -Wall -Werror -D_PSP_FW_VERSION=600"
 if test "$with_gprofflags" = yes ; then
 	PSPSDK_CFLAGS="$PSPSDK_CFLAGS -pg -g"
 fi


### PR DESCRIPTION
I think it's much better if we can see the CFLAGS value and can modify it.

ref: https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.72/autoconf.html#index-AC_005fPROG_005fCC-1