### PR TITLE
Include license files

### DIFF
--- a/build-and-install.sh
+++ b/build-and-install.sh
@@ -37,6 +37,13 @@ ln -sf "../sdk/lib/libpspuser.a" "libpspuser.a" || { exit 1; }
 ln -sf "../sdk/lib/libpspkernel.a" "libpspkernel.a" || { exit 1; }
 cd -
 
+# Copy licenses
+mkdir -p $PSPDEV/psp/share/licenses/pspsdk
+cp LICENSE $PSPDEV/psp/share/licenses/pspsdk/
+
+mkdir -p $PSPDEV/share/licenses/PrxEncrypter
+cp tools/PrxEncrypter/LICENSE $PSPDEV/share/licenses/PrxEncrypter
+
 ## Store build information
 BUILD_FILE="${PSPDEV}/build.txt"
 if [[ -f "${BUILD_FILE}" ]]; then


### PR DESCRIPTION
This one is important. We had forgotten to bundle the licenses of PrxEncrypter and the pspsdk. We should do a release once this has been merged.