### PR TITLE
Add options to disable some `newlib`functionalities

### DIFF
--- a/src/libcglue/cwd.c
+++ b/src/libcglue/cwd.c
@@ -178,6 +178,7 @@ int __path_absolute(const char *in, char *out, int len)
 
 #ifdef F___init_cwd
 /* Set the current working directory (CWD) to the path where the module was launched. */
+__attribute__((weak))
 void __init_cwd(char *argv_0)
 {
 	if (argv_0 != NULL) {

--- a/src/libcglue/pipe.c
+++ b/src/libcglue/pipe.c
@@ -92,6 +92,7 @@ int pipe(int fildes[2])
 #endif
 
 #ifdef F___pipe_close
+__attribute__((weak))
 int __pipe_close(int fd)
 {
 	int ret = 0;
@@ -124,6 +125,7 @@ int __pipe_close(int fd)
 #endif
 
 #ifdef F___pipe_nonblocking_read
+__attribute__((weak))
 int __pipe_nonblocking_read(int fd, void *buf, size_t len)
 {
 	int ret;
@@ -180,6 +182,7 @@ int __pipe_nonblocking_read(int fd, void *buf, size_t len)
 #endif
 
 #ifdef F___pipe_read
+__attribute__((weak))
 int __pipe_read(int fd, void *buf, size_t len)
 {
 	int ret;
@@ -241,6 +244,7 @@ int __pipe_read(int fd, void *buf, size_t len)
 #endif
 
 #ifdef F___pipe_write
+__attribute__((weak))
 int __pipe_write(int fd, const void *buf, size_t len)
 {
 	int ret;
@@ -286,6 +290,7 @@ int __pipe_write(int fd, const void *buf, size_t len)
 #endif
 
 #ifdef F___pipe_nonblocking_write
+__attribute__((weak))
 int __pipe_nonblocking_write(int fd, const void *buf, size_t len)
 {
 	int ret;

--- a/src/libcglue/socket.c
+++ b/src/libcglue/socket.c
@@ -53,6 +53,7 @@ int	socket(int domain, int type, int protocol)
    them in and have expanded socket capability. */
 
 #ifdef F___socket_close
+__attribute__((weak))
 int __socket_close(int sock)
 {
 	int ret = 0;
@@ -170,6 +171,7 @@ int	listen(int s, int backlog)
 #endif
 
 #ifdef F_recv
+__attribute__((weak))
 ssize_t	recv(int s, void *buf, size_t len, int flags)
 {
 	int ret;
@@ -212,6 +214,7 @@ ssize_t	recvfrom(int s, void *buf, size_t len, int flags, struct sockaddr *from,
 #endif
 
 #ifdef F_send
+__attribute__((weak))
 ssize_t	send(int s, const void *buf, size_t len, int flags)
 {
 	int ret;
@@ -275,6 +278,7 @@ int	getsockopt(int s, int level, int optname, void *optval, socklen_t *optlen)
 #endif
 
 #ifdef F_setsockopt
+__attribute__((weak))
 int	setsockopt(int s, int level, int optname, const void *optval, socklen_t optlen)
 {
 	int ret;

--- a/src/samples/Makefile.am
+++ b/src/samples/Makefile.am
@@ -56,6 +56,7 @@ SAMPLES = \
 	kernel/regenum \
 	kernel/systimer \
 	kernel/sysevent \
+	libcglue/light_elf \
 	mp3 \
 	ms/callback \
 	nand/dumpipl \

--- a/src/samples/Makefile.samples
+++ b/src/samples/Makefile.samples
@@ -53,6 +53,7 @@ SAMPLES = \
 	kernel/regenum \
 	kernel/systimer \
 	kernel/sysevent \
+	libcglue/light_elf \
 	mp3 \
 	ms/callback \
 	nand/dumpipl \

--- a/src/samples/libcglue/light_elf/Makefile.sample
+++ b/src/samples/libcglue/light_elf/Makefile.sample
@@ -1,0 +1,16 @@
+TARGET = light_size
+OBJS = main.o
+
+INCDIR = 
+CFLAGS = -Os -Wall -fdata-sections -ffunction-sections
+CXXFLAGS = $(CFLAGS) -fno-exceptions -fno-rtti
+ASFLAGS = $(CFLAGS)
+
+LIBDIR =
+LDFLAGS = -s 
+
+EXTRA_TARGETS = EBOOT.PBP
+PSP_EBOOT_TITLE = Light Hello World
+
+PSPSDK=$(shell psp-config --pspsdk-path)
+include $(PSPSDK)/lib/build.mak

--- a/src/samples/libcglue/light_elf/main.c
+++ b/src/samples/libcglue/light_elf/main.c
@@ -1,0 +1,44 @@
+/*
+ * PSP Software Development Kit - https://github.com/pspdev
+ * -----------------------------------------------------------------------
+ * Licensed under the BSD license, see LICENSE in PSPSDK root for details.
+ *
+ * 
+ * Sample program to demonstrate a minimalistic Hello World program.
+ * The main scope here is to show how we can disable newlib features if we don't need them.
+ */
+
+#include <stdio.h>
+
+// Specific psp headers
+#include <pspkernel.h>
+#include <pspdebug.h>
+#include <pspdisplay.h>
+#include <pspkernel.h>
+#include <pspmoduleinfo.h>
+#include <sys/socket.h>
+#include <errno.h>
+
+// We won't fully disable newlib as we are using printf
+// However we can disable timezone, pthreads, pipe and socket support
+PSP_DISABLE_NEWLIB_PIPE_SUPPORT()
+PSP_DISABLE_NEWLIB_SOCKET_SUPPORT()
+PSP_DISABLE_NEWLIB_TIMEZONE_SUPPORT()
+PSP_DISABLE_NEWLIB_CWD_SUPPORT()
+PSP_DISABLE_AUTOSTART_PTHREAD()
+ 
+// configure PSP stuff
+#define VERS    1
+#define REVS    0
+ 
+PSP_MODULE_INFO("Light Hello World", PSP_MODULE_USER, VERS, REVS);
+PSP_MAIN_THREAD_ATTR(PSP_THREAD_ATTR_USER);
+
+int main(int argc, char** argv)
+{
+    while(1) {
+        printf("Hello World!\n");
+    }
+    
+    return 0;
+}

--- a/src/user/pspmoduleinfo.h
+++ b/src/user/pspmoduleinfo.h
@@ -107,6 +107,37 @@ enum PspModuleInfoAttr
 	void __libcglue_init(int argc, char *argv[]) {} \
 	void __libcglue_deinit() {}
 
+/* Disable using pipe suuport from POSIX functions. */
+#define PSP_DISABLE_NEWLIB_PIPE_SUPPORT() \
+	static int __pipe_not_supported() { \
+		errno = ENOSYS; \
+		return -1; \
+	} \
+	int __pipe_close(int fd) { return __pipe_not_supported(); } \
+	int __pipe_nonblocking_read(int fd, void *buf, size_t len) { return __pipe_not_supported(); } \
+	int __pipe_read(int fd, void *buf, size_t len) { return __pipe_not_supported(); } \
+	int __pipe_write(int fd, const void *buf, size_t len) { return __pipe_not_supported(); } \
+	int __pipe_nonblocking_write(int fd, const void *buf, size_t len) { return __pipe_not_supported(); }
+
+/* Disable using socket suuport from POSIX functions. */
+#define PSP_DISABLE_NEWLIB_SOCKET_SUPPORT() \
+	static int __socket_not_supported() { \
+		errno = ENOSYS; \
+		return -1; \
+	} \
+	int __socket_close(int sock) { return __socket_not_supported(); } \
+	ssize_t	recv(int s, void *buf, size_t len, int flags) { return __socket_not_supported(); } \
+	ssize_t	send(int s, const void *buf, size_t len, int flags) { return __socket_not_supported(); } \
+	int	setsockopt(int s, int level, int optname, const void *optval, socklen_t optlen) { return __socket_not_supported(); } 
+
+/* Disable the timezone support from newlib. */
+#define PSP_DISABLE_NEWLIB_TIMEZONE_SUPPORT() \
+	void __timezone_update() { }
+
+/* Disable the CWD support from newlib. */
+#define PSP_DISABLE_NEWLIB_CWD_SUPPORT() \
+	void __init_cwd(char *argv_0) {}
+
 /* Disable the auto start of pthread on init for reducing binary size if not used. */
 #define PSP_DISABLE_AUTOSTART_PTHREAD() \
 	void __libpthreadglue_init() {}


### PR DESCRIPTION
## Description

The main scope of this PR is to allow the user to disable some concrete `newlib/POSIX` features to save RAM.
This is just for advanced users that understand what is going under the `crt0` and `libcglue` initialization.

I have added a new example where we see how we can reduce a dummy `hello world`.
```c
int main(int argc, char** argv) {
    while(1) { printf("Hello World!\n"); }
    return 0;
}
```

From `EBOOT.PBP` with `126664` bytes:
```c
-rw-r--r--  1 fjtrujy  staff  126664 Nov 29 17:29 EBOOT.PBP
-rw-r--r--  1 fjtrujy  staff     328 Nov 29 17:27 Makefile.sample
-rw-r--r--  1 fjtrujy  staff     324 Nov 29 17:29 PARAM.SFO
-rwxr-xr-x  1 fjtrujy  staff  126300 Nov 29 17:29 light_size.elf
-rw-r--r--  1 fjtrujy  staff    1167 Nov 29 17:29 main.c
-rw-r--r--  1 fjtrujy  staff    2140 Nov 29 17:29 main.o
```

To `EBOOT.PBP` with `50532` bytes:
```
-rw-r--r--  1 fjtrujy  staff  50532 Nov 29 18:22 EBOOT.PBP
-rw-r--r--  1 fjtrujy  staff    328 Nov 29 18:31 Makefile.sample
-rw-r--r--  1 fjtrujy  staff    324 Nov 29 18:22 PARAM.SFO
-rwxr-xr-x  1 fjtrujy  staff  50168 Nov 29 18:22 light_size.elf
-rw-r--r--  1 fjtrujy  staff   1176 Nov 29 18:31 main.c
-rw-r--r--  1 fjtrujy  staff   5052 Nov 29 18:22 main.o
```

Just putting in your `main.c` file:
```c
#include <sys/socket.h>
#include <errno.h>

PSP_DISABLE_NEWLIB_PIPE_SUPPORT()
PSP_DISABLE_NEWLIB_SOCKET_SUPPORT()
PSP_DISABLE_NEWLIB_TIMEZONE_SUPPORT()
PSP_DISABLE_NEWLIB_CWD_SUPPORT()
PSP_DISABLE_AUTOSTART_PTHREAD()
```

Cheers