### PR TITLE
Align memory to 16 when giving out vram for textures and buffers

### DIFF
--- a/src/gu/vram.c
+++ b/src/gu/vram.c
@@ -9,8 +9,9 @@
 #include <pspge.h>
 #include <pspgu.h>
 
+#define ALIGNMENT 16
+
 static unsigned int staticOffset = 0;
-static const unsigned int alignment = 16;
 
 static unsigned int getMemorySize(unsigned int width, unsigned int height, unsigned int psm)
 {
@@ -40,7 +41,7 @@ static unsigned int getMemorySize(unsigned int width, unsigned int height, unsig
 void* guGetStaticVramBuffer(unsigned int width, unsigned int height, unsigned int psm)
 {
 	unsigned int memSize = getMemorySize(width,height,psm);
-	staticOffset = (staticOffset + (alignment-1)) &~ (alignment-1);
+	staticOffset = (staticOffset + (ALIGNMENT-1)) &~ (ALIGNMENT-1);
 	void* result = (void*)staticOffset;
 	staticOffset += memSize;
 

--- a/src/gu/vram.c
+++ b/src/gu/vram.c
@@ -10,6 +10,7 @@
 #include <pspgu.h>
 
 static unsigned int staticOffset = 0;
+static const unsigned int alignment = 16;
 
 static unsigned int getMemorySize(unsigned int width, unsigned int height, unsigned int psm)
 {
@@ -39,6 +40,7 @@ static unsigned int getMemorySize(unsigned int width, unsigned int height, unsig
 void* guGetStaticVramBuffer(unsigned int width, unsigned int height, unsigned int psm)
 {
 	unsigned int memSize = getMemorySize(width,height,psm);
+	staticOffset = (staticOffset + (alignment-1)) &~ (alignment-1);
 	void* result = (void*)staticOffset;
 	staticOffset += memSize;
 


### PR DESCRIPTION
Right now when you use `guGetStaticVramTexture` you might see rendering issues because of an alignment mismatch. This PR aligns it to prevent this issue.