### PR TITLE
Add psp-create-license-directory script

### DIFF
--- a/m4/pspdev.m4
+++ b/m4/pspdev.m4
@@ -29,12 +29,15 @@ AC_DEFUN([AC_PSPDEV_PATH],
   pspdev_includedir="$pspdev/psp/include"
   pspdev_libdir="$pspdev/psp/lib"
   pspdev_sharedir="$pspdev/psp/share"
+  pspdev_bindir="$pspdev/bin"
   PSPDEV_INCLUDEDIR="$pspdev_includedir"
   PSPDEV_LIBDIR="$pspdev_libdir"
   PSPDEV_SHAREDIR="$pspdev_sharedir"
+  PSPDEV_BINDIR="$pspdev_bindir"
   AC_SUBST(PSPDEV_INCLUDEDIR)
   AC_SUBST(PSPDEV_LIBDIR)
   AC_SUBST(PSPDEV_SHAREDIR)
+  AC_SUBST(PSPDEV_BINDIR)
 ])
 
 dnl Check for a tool prefixed with "psp-".

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -21,3 +21,6 @@ psp_prxgen_SOURCES = psp-prxgen.c getopt_long.c
 psp_fixup_imports_SOURCES = psp-fixup-imports.c getopt_long.c sha1.c
 
 noinst_HEADERS = elftypes.h getopt.h prxtypes.h sha1.h types.h
+
+psp_create_license_directorydir = @PSPDEV_BINDIR@
+psp_create_license_directory_SCRIPTS = psp-create-license-directory

--- a/tools/psp-create-license-directory
+++ b/tools/psp-create-license-directory
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+LICENSE_DIRECTORY="third-party-licenses"
+EXIT_CODE=0
+LIBRARIES=("pspsdk" "newlib" "pthread-embedded" $@)
+SCRIPT_NAME="$(basename "$0")"
+
+usage ( ) {
+	cat <<EOF
+${SCRIPT_NAME} [OPTION] [LIBRARY]...
+The ${SCRIPT_NAME} tool makes it easier to comply with licenses of used libraries.
+It adds the licenses to the ${LICENSE_DIRECTORY} directory.
+The licenses for pspsdk, newlib and pthread-embedded are always addded,
+since they will always be compiled into your project.
+
+options:
+  -h		  Print this message
+  -l		  List installed libraries
+
+example:
+  If your project has included SDL2, SDL2_ttf and jsoncpp:
+
+    ${SCRIPT_NAME} sdl2 sdl2-ttf jsoncpp
+    
+  To get a list of installed libraries to get the name right use:
+
+    ${SCRIPT_NAME} -l
+
+EOF
+}
+
+get_dependencies ( ) {
+	if [ "${1}" != "pspsdk" ] && [ "${1}" != "newlib" ] && [ "${1}" != "pthread-embedded" ]; then
+		echo "$(psp-pacman -Qi ${1}|grep "^Depends On"|cut -d':' -f 2-|xargs echo)"
+	fi
+}
+
+copy_license_directory ( ) {
+	if [ -d "${PSPDEV}/psp/share/licenses/${1}" ]; then
+		if [ ! -d "${LICENSE_DIRECTORY}/${1}" ]; then
+			echo "Adding license for ${1} to ${LICENSE_DIRECTORY}"
+		fi
+		cp -rf "${PSPDEV}/psp/share/licenses/${1}" "${LICENSE_DIRECTORY}/"
+		for dependency in $(get_dependencies "${1}"); do
+			if [ "${dependency}" == "None" ]; then
+				continue
+			fi
+			if [ ! -d "${LICENSE_DIRECTORY}/${dependency}" ]; then
+				echo "Found dependency ${dependency} for ${1}"
+			fi
+			copy_license_directory "${dependency}"
+		done
+	else
+		echo "Failed to find license for library ${1}"
+		EXIT_CODE=2
+	fi
+}
+
+if [ -z "${PSPDEV}" ]; then
+    echo "The PSPDEV environment variable has not been set"
+    exit 1
+fi
+
+while getopts "hl" OPTION; do
+	case ${OPTION} in
+	h)
+		usage
+		exit 0
+	;;
+	l)
+		psp-pacman -Qq
+		exit 0
+	;;
+	*)
+		echo "${OPTION} - Unrecongnized option"
+		usage
+		exit 1
+	;;
+	esac
+done
+
+mkdir -p "${LICENSE_DIRECTORY}"
+for library in ${LIBRARIES[@]}; do
+	copy_license_directory "${library}"
+done
+exit ${EXIT_CODE}


### PR DESCRIPTION
This script can be used to create a directory called `third-party-licenses` which contain all the licenses for libraries used within your project. It uses psp-pacman to determine which licenses are relevant. All the user has to do it run it with a list of libraries that they use from PSPDEV.

Here is an example for a project that uses SDL2, some helper libraries for SDL2 and jsoncpp:
```
psp-create-license-directory sdl2 sdl2-ttf sdl2-image sdl2-mixer jsoncpp
```

The output would look like this:
```
Adding license for pspsdk to third-party-licenses
Adding license for newlib to third-party-licenses
Adding license for pthread-embedded to third-party-licenses
Adding license for sdl2 to third-party-licenses
Found dependency libpspvram for sdl2
Adding license for libpspvram to third-party-licenses
Found dependency pspgl for sdl2
Adding license for pspgl to third-party-licenses
Adding license for sdl2-ttf to third-party-licenses
Found dependency harfbuzz for sdl2-ttf
Adding license for harfbuzz to third-party-licenses
Found dependency freetype2 for harfbuzz
Adding license for freetype2 to third-party-licenses
Found dependency zlib for freetype2
Adding license for zlib to third-party-licenses
Found dependency bzip2 for freetype2
Adding license for bzip2 to third-party-licenses
Found dependency libpng for freetype2
Adding license for libpng to third-party-licenses
Adding license for sdl2-image to third-party-licenses
Found dependency jpeg for sdl2-image
Adding license for jpeg to third-party-licenses
Adding license for sdl2-mixer to third-party-licenses
Found dependency libmodplug for sdl2-mixer
Adding license for libmodplug to third-party-licenses
Found dependency libvorbis for sdl2-mixer
Adding license for libvorbis to third-party-licenses
Found dependency libogg for libvorbis
Adding license for libogg to third-party-licenses
Adding license for jsoncpp to third-party-licenses
```

The resulting directory would have the following content:
```
wouter@wouter-pc:~$ ls -R third-party-licenses/
third-party-licenses/:
bzip2      jsoncpp     libpspvram  pspsdk            sdl2-mixer
freetype2  libmodplug  libvorbis   pthread-embedded  sdl2-ttf
harfbuzz   libogg      newlib      sdl2              zlib
jpeg       libpng      pspgl       sdl2-image

third-party-licenses/bzip2:
COPYING

third-party-licenses/freetype2:
FTL.TXT  GPLv2.TXT  LICENSE.TXT

third-party-licenses/harfbuzz:
COPYING

third-party-licenses/jpeg:
README.ijg

third-party-licenses/jsoncpp:
LICENSE

third-party-licenses/libmodplug:
COPYING

third-party-licenses/libogg:
COPYING

third-party-licenses/libpng:
LICENSE

third-party-licenses/libpspvram:
LICENSE

third-party-licenses/libvorbis:
COPYING

third-party-licenses/newlib:
COPYING.NEWLIB

third-party-licenses/pspgl:
LICENSE

third-party-licenses/pspsdk:
LICENSE

third-party-licenses/pthread-embedded:
COPYING.LIB  COPYING.vita  README.md

third-party-licenses/sdl2:
LICENSE.txt

third-party-licenses/sdl2-image:
LICENSE.txt

third-party-licenses/sdl2-mixer:
LICENSE.txt

third-party-licenses/sdl2-ttf:
LICENSE.txt

third-party-licenses/zlib:
README
```

Additionally it has a `-l` option which makes it list the libraries installed.
