### PR TITLE
samples: Add kubrdige sample

### DIFF
--- a/src/samples/Makefile.am
+++ b/src/samples/Makefile.am
@@ -56,6 +56,7 @@ SAMPLES = \
 	kernel/regenum \
 	kernel/systimer \
 	kernel/sysevent \
+	kernel/userbridge \
 	mp3 \
 	ms/callback \
 	nand/dumpipl \

--- a/src/samples/Makefile.samples
+++ b/src/samples/Makefile.samples
@@ -53,6 +53,7 @@ SAMPLES = \
 	kernel/regenum \
 	kernel/systimer \
 	kernel/sysevent \
+	kernel/userbridge \
 	mp3 \
 	ms/callback \
 	nand/dumpipl \

--- a/src/samples/kernel/userbridge/Makefile.sample
+++ b/src/samples/kernel/userbridge/Makefile.sample
@@ -1,0 +1,7 @@
+SUBDIRS = kernel user
+
+all:
+	@for dir in $(SUBDIRS); do $(MAKE) -C $$dir; done
+
+clean:
+	@for dir in $(SUBDIRS); do $(MAKE) clean -C $$dir; done

--- a/src/samples/kernel/userbridge/Makefile.sample
+++ b/src/samples/kernel/userbridge/Makefile.sample
@@ -1,7 +1,8 @@
-SUBDIRS = kernel user
+SAMPLES = \
+	kernel \
+	user
 
 all:
-	@for dir in $(SUBDIRS); do $(MAKE) -C $$dir; done
-
-clean:
-	@for dir in $(SUBDIRS); do $(MAKE) clean -C $$dir; done
+	for sample in $(SAMPLES) ; do \
+		$(MAKE) -f Makefile.sample -C $$sample clean all || { exit 1; } \
+	done

--- a/src/samples/kernel/userbridge/kernel/Makefile.sample
+++ b/src/samples/kernel/userbridge/kernel/Makefile.sample
@@ -1,0 +1,26 @@
+TARGET = kernel
+OBJS = kernel.o exports.o
+
+PRX_EXPORTS = exports.exp
+
+# Use the kernel's small inbuilt libc
+USE_KERNEL_LIBC = 1
+# Use only kernel libraries
+USE_KERNEL_LIBS = 1
+
+INCDIR = 
+CFLAGS = -Os -G0 -Wall -fno-builtin-printf
+CXXFLAGS = $(CFLAGS) -fno-exceptions -fno-rtti
+ASFLAGS = $(CFLAGS)
+
+LIBDIR =
+
+LDFLAGS = -nostartfiles
+LIBS =
+
+PSPSDK=$(shell psp-config --pspsdk-path)
+include $(PSPSDK)/lib/build_prx.mak
+
+all:
+	psp-build-exports -s $(PRX_EXPORTS)
+	mv kernel.S "../user/"

--- a/src/samples/kernel/userbridge/kernel/exports.exp
+++ b/src/samples/kernel/userbridge/kernel/exports.exp
@@ -1,0 +1,16 @@
+# Define the exports for the prx
+PSP_BEGIN_EXPORTS
+
+# These four lines are mandatory (although you can add other functions like module_stop)
+# syslib is a psynonym for the single mandatory export.
+PSP_EXPORT_START(syslib, 0, 0x8000)
+PSP_EXPORT_FUNC(module_start)
+PSP_EXPORT_FUNC(module_stop)
+PSP_EXPORT_VAR(module_info)
+PSP_EXPORT_END
+
+PSP_EXPORT_START(kernel, 0, 0x4001)
+PSP_EXPORT_FUNC(pspSysregGetTachyonVersion)
+PSP_EXPORT_END
+
+PSP_END_EXPORTS

--- a/src/samples/kernel/userbridge/kernel/kernel.c
+++ b/src/samples/kernel/userbridge/kernel/kernel.c
@@ -1,3 +1,14 @@
+/*
+ * PSP Software Development Kit - https://github.com/pspdev
+ * -----------------------------------------------------------------------
+ * Licensed under the BSD license, see LICENSE in PSPSDK root for details.
+ *
+ * main.c - A basic example for checking the GProf profiler.
+ *
+ * Copyright (c) 2025 Joel16 - joel16dev@gmail.com
+ *
+ */
+ 
 #include <pspsdk.h>
 #include <pspsysreg.h>
 

--- a/src/samples/kernel/userbridge/kernel/kernel.c
+++ b/src/samples/kernel/userbridge/kernel/kernel.c
@@ -8,7 +8,6 @@
  * Copyright (c) 2025 Joel16 - joel16dev@gmail.com
  *
  */
- 
 #include <pspsdk.h>
 #include <pspsysreg.h>
 

--- a/src/samples/kernel/userbridge/kernel/kernel.c
+++ b/src/samples/kernel/userbridge/kernel/kernel.c
@@ -1,0 +1,23 @@
+#include <pspsdk.h>
+#include <pspsysreg.h>
+
+PSP_MODULE_INFO("kernel", PSP_MODULE_KERNEL, 1, 0);
+PSP_NO_CREATE_MAIN_THREAD();
+
+u32 pspSysregGetTachyonVersion(void) {
+    u32 k1 = pspSdkSetK1(0);
+
+    u32 ret = sceSysregGetTachyonVersion();
+        
+    pspSdkSetK1(k1);
+
+    return ret;
+}
+
+int module_start(SceSize args, void *argp) {
+    return 0;
+}
+
+int module_stop(void) {
+    return 0;
+}

--- a/src/samples/kernel/userbridge/user/Makefile.sample
+++ b/src/samples/kernel/userbridge/user/Makefile.sample
@@ -1,0 +1,18 @@
+TARGET = KUBridgeSample
+OBJS = main.o kernel.o
+
+INCDIR = 
+CFLAGS = -O2 -G0 -Wall
+CXXFLAGS = $(CFLAGS) -fno-exceptions -fno-rtti
+ASFLAGS = $(CFLAGS)
+
+LIBDIR =
+LDFLAGS =
+
+LIBS = -lpspkubridge
+
+EXTRA_TARGETS = EBOOT.PBP
+PSP_EBOOT_TITLE = KUBridgeSample
+
+PSPSDK=$(shell psp-config --pspsdk-path)
+include $(PSPSDK)/lib/build.mak

--- a/src/samples/kernel/userbridge/user/main.c
+++ b/src/samples/kernel/userbridge/user/main.c
@@ -1,3 +1,13 @@
+/*
+ * PSP Software Development Kit - https://github.com/pspdev
+ * -----------------------------------------------------------------------
+ * Licensed under the BSD license, see LICENSE in PSPSDK root for details.
+ *
+ * main.c - A basic example for checking the GProf profiler.
+ *
+ * Copyright (c) 2025 Joel16 - joel16dev@gmail.com
+ *
+ */
 #include <pspdebug.h>
 #include <pspkernel.h>
 #include <pspmodulemgr.h>

--- a/src/samples/kernel/userbridge/user/main.c
+++ b/src/samples/kernel/userbridge/user/main.c
@@ -1,0 +1,85 @@
+#include <pspdebug.h>
+#include <pspkernel.h>
+#include <pspmodulemgr.h>
+#include <kubridge.h>
+
+/* Define the module info section */
+PSP_MODULE_INFO("user", PSP_MODULE_USER, 1, 0);
+
+/* Define the main thread's attribute value (optional) */
+PSP_MAIN_THREAD_ATTR(THREAD_ATTR_USER | THREAD_ATTR_VFPU);
+
+int done = 0;
+
+/* Exit callback */
+int exitCallback(int arg1, int arg2, void *common) {
+    done = 1;
+    return 0;
+}
+
+/* Callback thread */
+int callbackThread(SceSize args, void *argp) {
+    int cbid = 0;
+    cbid = sceKernelCreateCallback("exitCallback", exitCallback, NULL);
+    sceKernelRegisterExitCallback(cbid);
+    sceKernelSleepThreadCB();
+    return 0;
+}
+
+/* Sets up the callback thread and returns its thread id */
+int setupCallbacks(void) {
+    int thid = sceKernelCreateThread("callbackThread", callbackThread, 0x11, 0xFA0, 0, 0);
+
+    if (thid >= 0) {
+        sceKernelStartThread(thid, 0, 0);
+    }
+        
+    return thid;
+}
+
+/* Load our kernel module */
+static SceUID loadStartModule(const char *path) {
+    int ret = 0, status = 0;
+    SceUID modID = 0;
+
+    ret = modID = kuKernelLoadModule(path, 0, NULL);
+    if (ret < 0) {
+        pspDebugScreenPrintf("kuKernelLoadModule(%s) failed: %08x\n", path, ret);
+        return ret;
+    }
+
+    ret = sceKernelStartModule(modID, 0, NULL, &status, NULL);
+    if (ret < 0) {
+        pspDebugScreenPrintf("sceKernelStartModule(%s) failed: %08x\n", path, ret);
+        return ret;
+    }
+    
+    return ret;
+}
+
+/* Unload our kernel module */
+static void stopUnloadModules(SceUID modID) {
+    sceKernelStopModule(modID, 0, NULL, NULL, NULL);
+    sceKernelUnloadModule(modID);
+}
+
+/* Kernel function prototype */
+u32 pspSysregGetTachyonVersion(void);
+
+int main(int argc, char *argv[]) {
+    // Initialize callbacks
+    pspDebugScreenInit();
+    setupCallbacks();
+
+    // Load and start kernel module
+    SceUID module = loadStartModule("kernel.prx");
+    u32 version = pspSysregGetTachyonVersion();
+
+    // Print kernel function result on screen
+    pspDebugScreenPrintf("Kernel User Bridge Sample:\n");
+    pspDebugScreenPrintf("sceSysregGetTachyonVersion returned %08lx\n", version);
+
+    // Unload and return
+    stopUnloadModules(module);
+    return 0;
+}


### PR DESCRIPTION
A short and sweet sample that demonstrates how to use a kernel function inside a usermode application. This involves using kubrdige to load the kernel module, and then using its exported kernel function inside a usermode application.