### PR TITLE
Added `#include <sys/syslimits.h>` to fix `PATH_MAX` not being define…

### DIFF
--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -31,6 +31,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/statvfs.h>
+#include <sys/syslimits.h>
 
 #include <psptypes.h>
 #include <pspiofilemgr.h>


### PR DESCRIPTION
Added `#include <sys/syslimits.h>` to fix `PATH_MAX` not being defined in `libcglue/glue.c`.