### PR TITLE
doc: add description to libraries

### DIFF
--- a/src/audio/pspaudio_kernel.h
+++ b/src/audio/pspaudio_kernel.h
@@ -18,6 +18,11 @@
 extern "C" {
 #endif
 
+/** @defgroup Audio User Audio Library
+  * This module contains the imports for audio frequencies.
+  */
+
+
 /** @defgroup Audio User Audio Library */
 
 /** @addtogroup Audio */

--- a/src/ctrl/pspctrl.h
+++ b/src/ctrl/pspctrl.h
@@ -22,6 +22,10 @@
 extern "C" {
 #endif
 
+/** @defgroup Ctrl Controller Kernel Library
+  * This module contains the imports for controllers (buttons, pad).
+  */
+
 /** @addtogroup Ctrl Controller Kernel Library */
 /**@{*/
 

--- a/src/umd/pspumd.h
+++ b/src/umd/pspumd.h
@@ -17,6 +17,10 @@
 extern "C" {
 #endif
 
+/** @defgroup UMD UMD Kernel Library
+  * This module contains the imports for UMD drive.
+  */
+
 /** @addtogroup UMD UMD Kernel Library */
 /**@{*/
 


### PR DESCRIPTION
The descriptions are displayed in the documentation generated by Doxygen.