### PR TITLE
fix: remove two warnings during documentation generation

### DIFF
--- a/src/user/pspthreadman.h
+++ b/src/user/pspthreadman.h
@@ -623,7 +623,7 @@ typedef struct {
  * @param name - The name of the lightweight mutex
  * @param attr - The LwMutex attributes, zero or more of ::PspLwMutexAttributes.
  * @param initialCount - THe inital value of the mutex
- * @param optionsPTr - Other optioons for mutex
+ * @param optionsPtr - Other options for mutex
  *
  * @return 0 on success, otherwise one of ::PspKernelErrorCodes
  */
@@ -663,7 +663,6 @@ int sceKernelLockLwMutex(SceLwMutexWorkarea *workarea, int lockCount, unsigned i
  * Lock a lightweight mutex
  *
  * @param workarea - The pointer to the workarea
- * @param name - The name of the lightweight mutex
  * @param lockCount - value of decrease the lock counter
  *
  * @return 0 on success, otherwise one of ::PspKernelErrorCodes


### PR DESCRIPTION
Doxygen displays two warnings (among others) because parameters filled in @params are not correct.

The warnings fixed are:

```
pspsdk/src/user/pspthreadman.h:622: warning: argument 'optionsPTr' of command @param is not found in the argument list of sceKernelCreateLwMutex(SceLwMutexWorkarea *workarea, const char *name, SceUInt32 attr, int initialCount, u32 *optionsPtr) pspsdk/src/user/pspthreadman.h:622: warning: The following parameter of sceKernelCreateLwMutex(SceLwMutexWorkarea *workarea, const char *name, SceUInt32 attr, int initialCount, u32 *optionsPtr) is not documented:
  parameter 'optionsPtr'
pspsdk/src/user/pspthreadman.h:665: warning: argument 'name' of command @param is not found in the argument list of sceKernelUnlockLwMutex(SceLwMutexWorkarea *workarea, int lockCount)
```

There is another type of warning about the source code documentation like:

```
pspsdk/src/prof/pspprof.h:28: warning: argument 'filename' of command @param is not found in the argument list of __attribute__((__no_instrument_function__, __no_profile_instrument_function__))
pspsdk/src/prof/pspprof.h:28: warning: argument 'should_dump' of command @param is not found in the argument list of __attribute__((__no_instrument_function__, __no_profile_instrument_function__))
/
```
There is the same case for prof.c:278.

The issue is the `__attribute__()` before the function definition. Moving the `__attribute__()` line above the comments does not solve the issue. So I did not fixed them.

Do you have any idea how to fix them?