### PR TITLE
doc: search improvement and link to constants

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2085,7 +2085,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2125,7 +2125,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = __attribute__(x)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/src/prof/pspprof.h
+++ b/src/prof/pspprof.h
@@ -24,6 +24,7 @@ extern "C" {
  */
 __attribute__((__no_instrument_function__, __no_profile_instrument_function__))
 void gprof_start(void);
+
 /**
  * Stop the profiler.
  * If the profiler is not running, this function does nothing.

--- a/src/vaudio/pspvaudio.h
+++ b/src/vaudio/pspvaudio.h
@@ -62,7 +62,7 @@ int sceVaudioOutputBlocking(int volume, void *buffer);
   *                      output call. One of 256, 576, 1024, 1152, 2048.
   *                      It must be a value between ::PSP_VAUDIO_SAMPLE_MIN and ::PSP_VAUDIO_SAMPLE_MAX.
   * @param frequency - The frequency. One of 48000, 44100, 32000, 24000, 22050, 16000, 12000, 11050, 8000.
-  * @param format - The output format to use for the channel. One of ::PSP_VAUDIO_FORMAT_
+  * @param format - The output format to use for the channel. One of ::PSP_VAUDIO_FORMAT_MONO or ::PSP_VAUDIO_FORMAT_STEREO
   *
   * @return 0 if success, < 0 on error.
   */
@@ -78,7 +78,7 @@ int sceVaudioChRelease(void);
 /**
   * Set effect type
   *
-  * @param effect - The effect type. One of ::PSP_VAUDIO_EFFECT_
+  * @param effect - The effect type. One of ::PSP_VAUDIO_EFFECT_OFF or ::PSP_VAUDIO_EFFECT_HEAVY or ::PSP_VAUDIO_EFFECT_POPS or ::PSP_VAUDIO_EFFECT_JAZZ or ::PSP_VAUDIO_EFFECT_UNIQUE or ::PSP_VAUDIO_EFFECT_MAX
   * @param volume - The volume. It must be a value between 0 and ::PSP_VAUDIO_VOLUME_MAX
   *
   * @return The volume value on success, < 0 on error.
@@ -88,7 +88,7 @@ int sceVaudioSetEffectType(int effect, int volume);
 /**
   * Set ALC(dynamic normalizer)
   *
-  * @param mode - The mode. One of ::PSP_VAUDIO_ALC_
+  * @param mode - The mode. One of ::PSP_VAUDIO_ALC_OFF or ::PSP_VAUDIO_ALC_MODE1 or ::PSP_VAUDIO_ALC_MODE_MAX
   *
   * @return 0 if success, < 0 on error.
   */


### PR DESCRIPTION
This patch fixes the search for function like `__mcount()` or `gprof_start()`. The issue existed for function with function attribute `(__attribute__())`: Doxygen didn't parsed it properly. It fixes such warnings:

```
warning: documented symbol '__mcount' was not declared or defined.
```

After changing Doxygen configuration to fix it, new warnings appears. For example: 

```
warning: explicit link request to 'PSP_VAUDIO_FORMAT_' could not be resolved
```

It's fixed by using the full name of the constants. By the way, it also fixes the link to the constants in the documentation.

Initial patch based on:
https://stackoverflow.com/questions/75410662/doxygen-does-not-parse-attribute-correctly

The first discussion about this issue is in https://github.com/pspdev/pspsdk/pull/266. The attempt with `@fn` was not satisfying because the search didn't work properly with such patch.