### PR TITLE
Fix SceSize declaration missing in pspdmac.h

### DIFF
--- a/src/base/psptypes.h
+++ b/src/base/psptypes.h
@@ -100,6 +100,7 @@ typedef int SceBool;
 typedef void SceVoid;
 typedef void * ScePVoid;
 
+typedef unsigned int SceSize;
 
 /* PSP types. */
 

--- a/src/dmac/pspdmac.h
+++ b/src/dmac/pspdmac.h
@@ -12,6 +12,7 @@
 #define __DMAC_H__
 
 #include <psptypes.h>
+#include <pspkerneltypes.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/dmac/pspdmac.h
+++ b/src/dmac/pspdmac.h
@@ -12,7 +12,6 @@
 #define __DMAC_H__
 
 #include <psptypes.h>
-#include <pspkerneltypes.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/kernel/psploadexec_kernel.h
+++ b/src/kernel/psploadexec_kernel.h
@@ -13,6 +13,7 @@
 #define PSPLOADEXEC_KERNEL_H
 
 #include <pspkerneltypes.h>
+#include <psptypes.h>
 #include <psploadexec.h>
 
 /** @defgroup LoadExecKernel Interface to the LoadExecForKernel library.

--- a/src/kernel/pspmodulemgr_kernel.h
+++ b/src/kernel/pspmodulemgr_kernel.h
@@ -15,6 +15,7 @@
 #define __MODMGRKERNEL_H__
 
 #include <pspkerneltypes.h>
+#include <psptypes.h>
 #include <pspmodulemgr.h>
 
 /** @defgroup ModuleMgrKern Kernel Module Manager Library

--- a/src/kernel/pspsysmem_kernel.h
+++ b/src/kernel/pspsysmem_kernel.h
@@ -17,6 +17,7 @@
 #define PSPSYSMEMKERNEL_H
 
 #include <pspkerneltypes.h>
+#include <psptypes.h>
 #include <pspsysmem.h>
 
 /** @defgroup SysMemKern System Memory Manager Kernel

--- a/src/kernel/pspthreadman_kernel.h
+++ b/src/kernel/pspthreadman_kernel.h
@@ -13,6 +13,7 @@
 #define PSPTHREADMANKERNEL_H
 
 #include <pspkerneltypes.h>
+#include <psptypes.h>
 #include <pspthreadman.h>
 
 /** @defgroup ThreadmanKern Thread Manager kernel functions

--- a/src/nand/pspnand_driver.h
+++ b/src/nand/pspnand_driver.h
@@ -13,6 +13,7 @@
 #define PSPNAND_DRIVER_H
 
 #include <pspkerneltypes.h>
+#include <psptypes.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/net/psphttp.h
+++ b/src/net/psphttp.h
@@ -14,6 +14,7 @@
 #define __PSPHTTP_H__
 
 #include <pspkerneltypes.h>
+#include <psptypes.h>
 
 #if defined(__cplusplus)
 extern "C" {

--- a/src/net/pspnet_resolver.h
+++ b/src/net/pspnet_resolver.h
@@ -20,6 +20,7 @@ extern "C" {
 
 #include <netinet/in.h>
 #include <pspkerneltypes.h>
+#include <psptypes.h>
 
 /**
  * Inititalise the resolver library

--- a/src/registry/pspreg.h
+++ b/src/registry/pspreg.h
@@ -16,6 +16,8 @@
 extern "C" {
 #endif
 
+#include <psptypes.h>
+
 /** @addtogroup Reg Registry Kernel Library */
 /**@{*/
 

--- a/src/samples/audio/polyphonic/main.c
+++ b/src/samples/audio/polyphonic/main.c
@@ -11,6 +11,7 @@
 #include <pspkernel.h>
 #include <pspdebug.h>
 #include <pspaudiolib.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>

--- a/src/samples/audio/wavegen/main.c
+++ b/src/samples/audio/wavegen/main.c
@@ -12,6 +12,7 @@
 #include <pspaudio.h>
 #include <pspdisplay.h>
 #include <pspctrl.h>
+#include <psptypes.h>
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/samples/controller/basic/main.c
+++ b/src/samples/controller/basic/main.c
@@ -17,6 +17,7 @@
 #include <pspctrl.h>
 #include <stdlib.h>
 #include <string.h>
+#include <psptypes.h>
 
 /* Define the module info section */
 PSP_MODULE_INFO("CONTROLTEST", 0, 1, 1);

--- a/src/samples/debug/debugkb/main.c
+++ b/src/samples/debug/debugkb/main.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <pspdebugkb.h>
+#include <psptypes.h>
 
 /* Define the module info section */
 PSP_MODULE_INFO("Debug Screen Text Input", 0, 1, 1);

--- a/src/samples/debug/exception/main.c
+++ b/src/samples/debug/exception/main.c
@@ -14,6 +14,7 @@
 #include <pspdebug.h>
 #include <pspctrl.h>
 #include <pspdisplay.h>
+#include <psptypes.h>
 
 PSP_MODULE_INFO("EXTEST", 0x1000, 1, 1);
 /* Define the main thread's attribute value (optional) */

--- a/src/samples/debug/gdb/main.c
+++ b/src/samples/debug/gdb/main.c
@@ -15,6 +15,7 @@
 #include <pspctrl.h>
 #include <pspdisplay.h>
 #include <stdio.h>
+#include <psptypes.h>
 
 PSP_MODULE_INFO("EXTEST", 0x1000, 1, 1);
 /* Define the main thread's attribute value (optional) */

--- a/src/samples/debug/kprintf/main.c
+++ b/src/samples/debug/kprintf/main.c
@@ -12,6 +12,7 @@
  */
 #include <pspkernel.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 
 PSP_MODULE_INFO("KPTEST", 0x1000, 1, 1);
 /* Define the main thread's attribute value (optional) */

--- a/src/samples/debug/profiler/main.c
+++ b/src/samples/debug/profiler/main.c
@@ -13,6 +13,7 @@
 #include <pspkernel.h>
 #include <pspdebug.h>
 #include <pspdisplay.h>
+#include <psptypes.h>
 #include <string.h>
 
 PSP_MODULE_INFO("PROFILER", 0x1000, 1, 1);

--- a/src/samples/debug/prxdecrypt/main.c
+++ b/src/samples/debug/prxdecrypt/main.c
@@ -12,6 +12,7 @@
  */
 #include <pspkernel.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/samples/gu/clut/clut.c
+++ b/src/samples/gu/clut/clut.c
@@ -9,6 +9,7 @@
 #include <pspkernel.h>
 #include <pspdisplay.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/samples/gu/common/callbacks.c
+++ b/src/samples/gu/common/callbacks.c
@@ -9,6 +9,7 @@
 #include <pspkernel.h>
 #include <pspdisplay.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/samples/gu/morph/morph.c
+++ b/src/samples/gu/morph/morph.c
@@ -9,6 +9,7 @@
 #include <pspkernel.h>
 #include <pspdisplay.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/samples/gu/morphskin/morphskin.c
+++ b/src/samples/gu/morphskin/morphskin.c
@@ -13,6 +13,7 @@
 #include <pspkernel.h>
 #include <pspdisplay.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/samples/gu/reflection/reflection.c
+++ b/src/samples/gu/reflection/reflection.c
@@ -10,6 +10,7 @@
 #include <pspkernel.h>
 #include <pspdisplay.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/samples/gu/rendertarget/rendertarget.c
+++ b/src/samples/gu/rendertarget/rendertarget.c
@@ -13,6 +13,7 @@
 #include <pspkernel.h>
 #include <pspdisplay.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/samples/gu/shadowprojection/shadowprojection.c
+++ b/src/samples/gu/shadowprojection/shadowprojection.c
@@ -13,6 +13,7 @@
 #include <pspkernel.h>
 #include <pspdisplay.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/samples/gu/signals/signals.c
+++ b/src/samples/gu/signals/signals.c
@@ -22,6 +22,7 @@
 #include <pspkernel.h>
 #include <pspdisplay.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/samples/gu/skinning/skinning.c
+++ b/src/samples/gu/skinning/skinning.c
@@ -12,6 +12,7 @@
 #include <pspkernel.h>
 #include <pspdisplay.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/samples/gu/spharm/cube.c
+++ b/src/samples/gu/spharm/cube.c
@@ -2,6 +2,7 @@
 #include <pspdisplay.h>
 #include <pspdebug.h>
 #include <pspctrl.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/samples/gu/text/main.c
+++ b/src/samples/gu/text/main.c
@@ -13,6 +13,7 @@
 #include <pspgu.h>
 #include <pspgum.h>
 #include <pspdisplay.h>
+#include <psptypes.h>
 
 #include <string.h>
 #include <math.h>

--- a/src/samples/gu/timing/timing.c
+++ b/src/samples/gu/timing/timing.c
@@ -21,6 +21,7 @@
 #include <pspgu.h>
 #include <pspgum.h>
 #include <pspctrl.h>
+#include <psptypes.h>
 
 PSP_MODULE_INFO("Timing Sample", 0, 1, 1);
 PSP_MAIN_THREAD_ATTR(THREAD_ATTR_USER);

--- a/src/samples/ir/irda/main.c
+++ b/src/samples/ir/irda/main.c
@@ -13,6 +13,7 @@
 #include <pspdisplay.h>
 #include <pspctrl.h>
 #include <pspsircs.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/samples/ir/sircs/main.c
+++ b/src/samples/ir/sircs/main.c
@@ -17,6 +17,7 @@
 #include <pspdisplay.h>
 #include <pspctrl.h>
 #include <pspsircs.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/samples/kernel/fileio/main.c
+++ b/src/samples/kernel/fileio/main.c
@@ -14,6 +14,7 @@
 #include <pspctrl.h>
 #include <pspdebug.h>
 #include <pspdisplay.h>
+#include <psptypes.h>
 #include <pspumd.h>
 
 #include <string.h>

--- a/src/samples/kernel/idstorage/main.c
+++ b/src/samples/kernel/idstorage/main.c
@@ -10,6 +10,7 @@
  */
 #include <pspkernel.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 #include <pspidstorage.h>
 
 /* Start in kernel mode */

--- a/src/samples/kernel/kdumper/main.c
+++ b/src/samples/kernel/kdumper/main.c
@@ -12,6 +12,7 @@
  */
 #include <pspkernel.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/samples/kernel/loadmodule/main.c
+++ b/src/samples/kernel/loadmodule/main.c
@@ -16,6 +16,7 @@
 #include <pspuser.h>
 #include <pspdebug.h>
 #include <pspsdk.h>
+#include <psptypes.h>
 #include <string.h>
 
 /* Define the module info section, note the 0x1000 flag to enable start in kernel mode */

--- a/src/samples/kernel/messagebox/main.c
+++ b/src/samples/kernel/messagebox/main.c
@@ -11,6 +11,7 @@
 #include <pspkernel.h>
 #include <pspdebug.h>
 #include <pspthreadman.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/samples/kernel/regenum/main.c
+++ b/src/samples/kernel/regenum/main.c
@@ -13,6 +13,7 @@
 #include <pspreg.h>
 #include <pspctrl.h>
 #include <pspdisplay.h>
+#include <psptypes.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/samples/kernel/threadstatus/main.c
+++ b/src/samples/kernel/threadstatus/main.c
@@ -12,6 +12,7 @@
  */
 #include <pspkernel.h>
 #include <pspdebug.h>
+#include <psptypes.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/samples/mp3/main.c
+++ b/src/samples/mp3/main.c
@@ -16,6 +16,7 @@
 #include <pspaudio.h>
 #include <pspmp3.h>
 #include <psputility.h>
+#include <psptypes.h>
 
 
 /* Define the module info section */

--- a/src/samples/nand/dumpipl/main.c
+++ b/src/samples/nand/dumpipl/main.c
@@ -26,6 +26,7 @@
 #include <pspuser.h>
 #include <pspdebug.h>
 #include <pspnand_driver.h>
+#include <psptypes.h>
 
 /* Define the module info section */
 PSP_MODULE_INFO("dumpipl", 0x1000, 1, 1);

--- a/src/samples/net/resolver/main.c
+++ b/src/samples/net/resolver/main.c
@@ -19,6 +19,7 @@
 #include <pspnet_inet.h>
 #include <pspnet_apctl.h>
 #include <pspnet_resolver.h>
+#include <psptypes.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <sys/select.h>

--- a/src/samples/net/simple/main.c
+++ b/src/samples/net/simple/main.c
@@ -15,6 +15,7 @@
 #include <pspnet_apctl.h>
 #include <pspsdk.h>
 #include <psputility.h>
+#include <psptypes.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/src/samples/net/simple_prx/main.c
+++ b/src/samples/net/simple_prx/main.c
@@ -21,6 +21,7 @@
 #include <pspnet_inet.h>
 #include <pspnet_apctl.h>
 #include <pspnet_resolver.h>
+#include <psptypes.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <sys/select.h>

--- a/src/samples/net/wlanscan_elf/main.c
+++ b/src/samples/net/wlanscan_elf/main.c
@@ -19,6 +19,7 @@
 #include <pspwlan.h>
 #include <pspctrl.h>
 #include <pspdisplay.h>
+#include <psptypes.h>
 
 #define printf pspDebugScreenPrintf
 

--- a/src/samples/power/main.c
+++ b/src/samples/power/main.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <pspmoduleinfo.h>
 #include <psppower.h>
+#include <psptypes.h>
 
 /* Define the module info section */
 PSP_MODULE_INFO("PowerTest", 0, 0, 71);

--- a/src/samples/savedata/utility/main.c
+++ b/src/samples/savedata/utility/main.c
@@ -22,6 +22,7 @@
 #include <pspgum.h>
 #include <psputility.h>
 #include <pspctrl.h>
+#include <psptypes.h>
 
 #include "data.h"
 

--- a/src/samples/template/kprx_template/main.c
+++ b/src/samples/template/kprx_template/main.c
@@ -11,6 +11,7 @@
  *
  */
 #include <pspkernel.h>
+#include <psptypes.h>
 #include <stdio.h>
 
 PSP_MODULE_INFO("template", PSP_MODULE_KERNEL, 1, 1);

--- a/src/samples/usb/storage/main.c
+++ b/src/samples/usb/storage/main.c
@@ -21,6 +21,7 @@
 #include <pspthreadman.h>
 #include <pspctrl.h>
 #include <pspsdk.h>
+#include <psptypes.h>
 
 /**
  * Define the module info section

--- a/src/samples/utility/msgdialog/main.c
+++ b/src/samples/utility/msgdialog/main.c
@@ -19,6 +19,7 @@
 #include <psputility.h>
 #include <pspgu.h>
 #include <pspgum.h>
+#include <psptypes.h>
 
 /* Define the module info section */
 PSP_MODULE_INFO("MsgDialog Sample", 0, 1, 0);

--- a/src/samples/utility/netconf/main.c
+++ b/src/samples/utility/netconf/main.c
@@ -16,6 +16,7 @@
 #include <pspmoduleinfo.h>
 #include <psputility.h>
 #include <pspctrl.h>
+#include <psptypes.h>
 
 /* Define the module info section */
 PSP_MODULE_INFO("NetParam Sample", 0, 1, 00);

--- a/src/samples/utility/netdialog/main.c
+++ b/src/samples/utility/netdialog/main.c
@@ -22,6 +22,7 @@
 #include <pspnet.h>
 #include <pspnet_inet.h>
 #include <pspnet_apctl.h>
+#include <psptypes.h>
 
 #if defined(_PSP_FW_VERSION) && _PSP_FW_VERSION >= 200
 PSP_MODULE_INFO("Net Dialog Sample", 0, 1, 1);

--- a/src/samples/utility/osk/main.c
+++ b/src/samples/utility/osk/main.c
@@ -4,6 +4,7 @@
 #include <pspgu.h>
 #include <string.h>
 #include <psputility.h>
+#include <psptypes.h>
 
 PSP_MODULE_INFO("OSK Sample", 0, 1, 1);
 PSP_MAIN_THREAD_ATTR(THREAD_ATTR_USER);

--- a/src/samples/utility/systemparam/main.c
+++ b/src/samples/utility/systemparam/main.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <pspmoduleinfo.h>
 #include <psputility.h>
+#include <psptypes.h>
 
 /* Define the module info section */
 PSP_MODULE_INFO("SystemParam Sample", 0, 1, 0);

--- a/src/samples/wlan/main.c
+++ b/src/samples/wlan/main.c
@@ -11,6 +11,7 @@
 #include <pspkernel.h>
 #include <pspdebug.h>
 #include <pspdisplay.h>
+#include <psptypes.h>
 #include <stdio.h>
 #include <string.h>
 //#include <pspmoduleinfo.h>

--- a/src/sdk/memory.c
+++ b/src/sdk/memory.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <pspsdk.h>
+#include <psptypes.h>
 
 static u32 _pspSdkGetMaxLineareMemorySize(void)
 {

--- a/src/sdk/pspsdk.h
+++ b/src/sdk/pspsdk.h
@@ -15,6 +15,7 @@
 #define PSPSDK_H
 
 #include <pspkerneltypes.h>
+#include <psptypes.h>
 #include <pspmodulemgr.h>
 #include <pspmoduleinfo.h>
 #include <pspthreadman.h>

--- a/src/sdk/threadutils.c
+++ b/src/sdk/threadutils.c
@@ -13,6 +13,7 @@
 
 #include "pspthreadman.h"
 #include "pspsdk.h"
+#include "psptypes.h"
 
 #define MAX_UIDS 256
 

--- a/src/startup/crt0.c
+++ b/src/startup/crt0.c
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include <pspkerneltypes.h>
+#include <psptypes.h>
 #include <pspmoduleinfo.h>
 #include <pspthreadman.h>
 #include <psploadexec.h>

--- a/src/startup/crt0_prx.c
+++ b/src/startup/crt0_prx.c
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include <pspkerneltypes.h>
+#include <psptypes.h>
 #include <pspmoduleinfo.h>
 #include <pspthreadman.h>
 #include <psploadexec.h>

--- a/src/usb/pspusbcam.h
+++ b/src/usb/pspusbcam.h
@@ -15,6 +15,8 @@
 extern "C" {
 #endif
 
+#include <psptypes.h>
+
 #define PSP_USBCAM_PID				    (0x282)
 #define PSP_USBCAM_DRIVERNAME		  "USBCamDriver"
 #define PSP_USBCAMMIC_DRIVERNAME	"USBCamMicDriver"

--- a/src/user/pspiofilemgr.h
+++ b/src/user/pspiofilemgr.h
@@ -14,6 +14,7 @@
 #define __FILEIO_H__
 
 #include <pspkerneltypes.h>
+#include <psptypes.h>
 #include <pspiofilemgr_fcntl.h>
 #include <pspiofilemgr_stat.h>
 #include <pspiofilemgr_dirent.h>

--- a/src/user/psploadexec.h
+++ b/src/user/psploadexec.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+#include <psptypes.h>
+
 /** @addtogroup LoadExec */
 
 /**@{*/

--- a/src/user/pspmodulemgr.h
+++ b/src/user/pspmodulemgr.h
@@ -19,6 +19,7 @@
 #define __MODLOAD_H__
 
 #include <pspkerneltypes.h>
+#include <psptypes.h>
 
 /** @defgroup ModuleMgr Module Manager Library
   * This module contains the imports for the kernel's module management routines.

--- a/src/user/pspsysmem.h
+++ b/src/user/pspsysmem.h
@@ -17,6 +17,7 @@
 #define PSPSYSMEM_H
 
 #include <pspkerneltypes.h>
+#include <psptypes.h>
 
 /** @defgroup SysMem System Memory Manager
   * This module contains routines to manage heaps of memory.


### PR DESCRIPTION
@wally4000 reported this error:
```
In file included from /home/ben/daedalus_wally/Source/HLEAudio/Plugin/PSP/AudioPluginPSP.h:3,
                 from /home/ben/daedalus_wally/Source/System/SystemInit.cpp:44:
/home/ben/pspdev/psp/sdk/include/pspdmac.h:29:47: error: 'SceSize' has not been declared
   29 | int sceDmacMemcpy(void *dst, const void *src, SceSize n);
      |                                               ^~~~~~~
/home/ben/pspdev/psp/sdk/include/pspdmac.h:31:50: error: 'SceSize' has not been declared
   31 | int sceDmacTryMemcpy(void *dst, const void *src, SceSize n);
      |         
```
This should fix that. Since SceSize is defined in pspkerneltypes.h.