### PR TITLE
Move generated documentation in dedicated directory

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -29,5 +29,5 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./doc/html
+        publish_dir: ./doc/build/html
         force_orphan: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-doc
+doc/build
 
 *.o
 *.a

--- a/Doxyfile
+++ b/Doxyfile
@@ -68,7 +68,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = doc
+OUTPUT_DIRECTORY       = doc/build
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create up to 4096
 # sub-directories (in 2 levels) under the output directory of each output format
@@ -2416,7 +2416,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       = doc/pspsdk.tag
+GENERATE_TAGFILE       = doc/build/pspsdk.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external classes and namespaces
 # will be listed in the class and namespace index. If set to NO, only the

--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,7 @@ DX_RTF_FEATURE(OFF)
 DX_XML_FEATURE(OFF)
 DX_PDF_FEATURE(OFF)
 DX_PS_FEATURE(OFF)
-DX_INIT_DOXYGEN(PSPSDK, Doxyfile, doc)
+DX_INIT_DOXYGEN(PSPSDK, Doxyfile, doc/build)
 
 # Override the default prefix to point to where the pspdev tools should be installed.
 # The binaries will end up in $prefix/bin, but pspsdk itself will end up in $prefix/$target/sdk.


### PR DESCRIPTION
The documentation generated by Doxygen moves from `doc/` to `doc/build/`.
There is a problem with using `doc/` directory because when Doxygen produces the documentation, the `doc/` directory is replaced so its content (`style.css` file) disappears.
