### PR TITLE
Improve `sceGu`

### DIFF
--- a/src/gu/pspgu.h
+++ b/src/gu/pspgu.h
@@ -580,7 +580,7 @@ void* sceGuSwapBuffers(void);
   *
   * @par Example: Wait for the currently executing display list
   * @code
-  * sceGuSync(0,0);
+  * sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
   * @endcode
   *
   * Available what are:

--- a/src/gu/sceGuFinish.c
+++ b/src/gu/sceGuFinish.c
@@ -8,42 +8,6 @@
 
 #include "guInternal.h"
 
-int sceGuFinish(void)
-{
-	switch (gu_curr_context)
-	{
-	case GU_DIRECT:
-	case GU_SEND:
-	{
-		sendCommandi(FINISH, 0);
-		sendCommandiStall(END, 0);
-	}
-	break;
-
-	case GU_CALL:
-	{
-		if (gu_call_mode == 1)
-		{
-			sendCommandi(SIGNAL, 0x120000);
-			sendCommandi(END, 0);
-			sendCommandiStall(NOP, 0);
-		}
-		else
-		{
-			sendCommandi(RET, 0);
-		}
-	}
-	break;
-	}
-
-	unsigned int size = ((unsigned int)gu_list->current) - ((unsigned int)gu_list->start);
-
-	// go to parent list
-	gu_curr_context = gu_list->parent_context;
-	gu_list = &gu_contexts[gu_curr_context].list;
-	return size;
-}
-
 int sceGuFinishId(unsigned int id)
 {
 	switch (gu_curr_context)
@@ -78,4 +42,9 @@ int sceGuFinishId(unsigned int id)
 	gu_curr_context = gu_list->parent_context;
 	gu_list = &gu_contexts[gu_curr_context].list;
 	return size;
+}
+
+int sceGuFinish(void)
+{
+	return sceGuFinishId(0);
 }

--- a/src/gu/sceGuSync.c
+++ b/src/gu/sceGuSync.c
@@ -15,9 +15,9 @@ int sceGuSync(int mode, int what)
 {
 	switch (mode)
 	{
-		case 0: return sceGeDrawSync(what);
-		case 3: return sceGeListSync(ge_list_executed[0],what);
-		case 4: return sceGeListSync(ge_list_executed[1],what);
-		default: case 1: case 2: return 0;
+		case GU_SYNC_FINISH: return sceGeDrawSync(what);
+		case GU_SYNC_LIST: return sceGeListSync(ge_list_executed[0],what);
+		case GU_SYNC_SEND: return sceGeListSync(ge_list_executed[1],what);
+		default: case GU_SYNC_SIGNAL: case GU_SYNC_DONE: return 0;
 	}
 }

--- a/src/samples/gu/beginobject/beginobject.c
+++ b/src/samples/gu/beginobject/beginobject.c
@@ -141,7 +141,7 @@ int main(int argc, char* argv[]) {
 	sceGuEnable(GU_CLIP_PLANES);
 	sceGuSetCallback(GU_CALLBACK_SIGNAL, gucallback);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
 	
@@ -217,7 +217,7 @@ int main(int argc, char* argv[]) {
 		}
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		pspDebugScreenSetOffset((int)buffer);
 		pspDebugScreenSetXY(0,0);

--- a/src/samples/gu/blend/blend.c
+++ b/src/samples/gu/blend/blend.c
@@ -111,7 +111,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_BLEND);
 	sceGuClear(GU_COLOR_BUFFER_BIT|GU_DEPTH_BUFFER_BIT);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -180,7 +180,7 @@ int main(int argc, char* argv[])
 		// wait for next frame
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/blit/blit.c
+++ b/src/samples/gu/blit/blit.c
@@ -149,7 +149,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_TEXTURE_2D);
 	sceGuClear(GU_COLOR_BUFFER_BIT|GU_DEPTH_BUFFER_BIT);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(1);
@@ -214,7 +214,7 @@ int main(int argc, char* argv[])
 			simpleBlit(0,0,SCR_WIDTH,SCR_HEIGHT,0,0);
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		float curr_fps = 1.0f / curr_ms;
 

--- a/src/samples/gu/celshading/celshading.c
+++ b/src/samples/gu/celshading/celshading.c
@@ -132,7 +132,7 @@ int main(int argc, char* argv[]) {
 	sceGuEnable(GU_CULL_FACE);
 	sceGuEnable(GU_CLIP_PLANES);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
 
@@ -207,7 +207,7 @@ int main(int argc, char* argv[]) {
 		}
 		
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceCtrlReadBufferPositive(&pad, 1);
 		

--- a/src/samples/gu/clut/clut.c
+++ b/src/samples/gu/clut/clut.c
@@ -94,7 +94,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_TEXTURE_2D);
 	sceGuClear(GU_COLOR_BUFFER_BIT|GU_DEPTH_BUFFER_BIT);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -146,7 +146,7 @@ int main(int argc, char* argv[])
 		// wait for next frame
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/copy/copy.c
+++ b/src/samples/gu/copy/copy.c
@@ -63,7 +63,7 @@ int main(int argc, char* argv[])
 	sceGuFrontFace(GU_CW);
 	sceGuClear(GU_COLOR_BUFFER_BIT|GU_DEPTH_BUFFER_BIT);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(1);
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
 		sceGuTexSync();
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		float curr_fps = 1.0f / curr_ms;
 

--- a/src/samples/gu/cube/cube.c
+++ b/src/samples/gu/cube/cube.c
@@ -116,7 +116,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_TEXTURE_2D);
 	sceGuEnable(GU_CLIP_PLANES);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -169,7 +169,7 @@ int main(int argc, char* argv[])
 		sceGumDrawArray(GU_TRIANGLES,GU_TEXTURE_32BITF|GU_COLOR_8888|GU_VERTEX_32BITF|GU_TRANSFORM_3D,12*3,0,vertices);
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/envmap/envmap.c
+++ b/src/samples/gu/envmap/envmap.c
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_LIGHTING);
 	sceGuEnable(GU_LIGHT0);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
 
@@ -196,7 +196,7 @@ int main(int argc, char* argv[])
 		oldButtons = pad.Buttons;
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 //		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/integerdrawing/integerdrawing.c
+++ b/src/samples/gu/integerdrawing/integerdrawing.c
@@ -215,7 +215,7 @@ int main(int argc, char* argv[]) {
 	sceGuAmbientColor(0xffffffff);
 
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
 	
@@ -269,7 +269,7 @@ int main(int argc, char* argv[]) {
 		old = pad.Buttons;
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		pspDebugScreenSetOffset((int)buffer);
 		pspDebugScreenSetXY(0, 0);

--- a/src/samples/gu/lights/lights.c
+++ b/src/samples/gu/lights/lights.c
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_LIGHT2);
 	sceGuEnable(GU_LIGHT3);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
 
@@ -171,7 +171,7 @@ int main(int argc, char* argv[])
 		sceGumDrawArray(GU_TRIANGLES,NP_VERTEX_FORMAT|GU_INDEX_16BIT|GU_TRANSFORM_3D,sizeof(torus_indices)/sizeof(unsigned short),torus_indices,torus_vertices);
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/lines/lines.c
+++ b/src/samples/gu/lines/lines.c
@@ -103,7 +103,7 @@ int main(int argc, char* argv[])
 	sceGuScissor(0,0,SCR_WIDTH,SCR_HEIGHT);
 	sceGuEnable(GU_SCISSOR_TEST);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -197,7 +197,7 @@ int main(int argc, char* argv[])
 		// wait for next frame
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/logic/logic.c
+++ b/src/samples/gu/logic/logic.c
@@ -81,7 +81,7 @@ int main(int argc, char* argv[])
 	sceGuScissor(0,0,SCR_WIDTH,SCR_HEIGHT);
 	sceGuEnable(GU_SCISSOR_TEST);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
 
@@ -140,7 +140,7 @@ int main(int argc, char* argv[])
 		sceGuDisable(GU_COLOR_LOGIC_OP);
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		gettimeofday(&tv,0);
 		if ((tv.tv_sec-base_time.tv_sec) > TIME_SLICE)

--- a/src/samples/gu/mipmapping/mipmapping.c
+++ b/src/samples/gu/mipmapping/mipmapping.c
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_TEXTURE_2D);
 	//sceGuEnable(GU_CLIP_PLANES);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -136,7 +136,7 @@ int main(int argc, char* argv[])
 		sceGumDrawArray(GU_TRIANGLES,GU_TEXTURE_32BITF|GU_VERTEX_32BITF|GU_TRANSFORM_3D,2*3,0,vertices);
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/morph/morph.c
+++ b/src/samples/gu/morph/morph.c
@@ -127,7 +127,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_LIGHTING);
 	sceGuEnable(GU_LIGHT0);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -182,7 +182,7 @@ int main(int argc, char* argv[])
 		sceGumDrawArray(GU_TRIANGLES,GU_COLOR_8888|GU_NORMAL_32BITF|GU_VERTEX_32BITF|GU_VERTICES(2)|GU_INDEX_16BIT|GU_TRANSFORM_3D,sizeof(indices)/sizeof(unsigned short),indices,vertices);
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/morphskin/morphskin.c
+++ b/src/samples/gu/morphskin/morphskin.c
@@ -114,7 +114,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_LIGHT0);
 
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -204,7 +204,7 @@ int main(int argc, char* argv[])
 		}
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/ortho/ortho.c
+++ b/src/samples/gu/ortho/ortho.c
@@ -66,7 +66,7 @@ int main(int argc, char* argv[])
 	sceGuShadeModel(GU_SMOOTH);
 	sceGuDisable(GU_TEXTURE_2D);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
  
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(1);
@@ -118,7 +118,7 @@ int main(int argc, char* argv[])
                 sceGumDrawArray(GU_TRIANGLES,GU_COLOR_8888|GU_VERTEX_32BITF|GU_TRANSFORM_3D,1*3,0,vertices);
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		pspDebugScreenSetOffset((int)fbp0);
 		pspDebugScreenSetXY(0,0);

--- a/src/samples/gu/reflection/reflection.c
+++ b/src/samples/gu/reflection/reflection.c
@@ -131,7 +131,7 @@ int main(int argc, char* argv[])
 	sceGuShadeModel(GU_SMOOTH);
 	sceGuEnable(GU_CULL_FACE);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -256,7 +256,7 @@ int main(int argc, char* argv[])
 		sceGuDisable(GU_TEXTURE_2D);
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/rendertarget/rendertarget.c
+++ b/src/samples/gu/rendertarget/rendertarget.c
@@ -262,7 +262,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_CULL_FACE);
 	sceGuEnable(GU_TEXTURE_2D);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -321,7 +321,7 @@ int main(int argc, char* argv[])
 		}
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		frameBuffer = sceGuSwapBuffers();

--- a/src/samples/gu/shadowprojection/shadowprojection.c
+++ b/src/samples/gu/shadowprojection/shadowprojection.c
@@ -160,7 +160,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_TEXTURE_2D);
 	sceGuEnable(GU_DITHER);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -307,7 +307,7 @@ int main(int argc, char* argv[])
 			drawShadowCaster( &torus );
 
 			sceGuFinish();
-			sceGuSync(0,0);
+			sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 		}
 
 		// render to frame buffer
@@ -377,7 +377,7 @@ int main(int argc, char* argv[])
 			drawShadowReceiver( &grid, shadowProj );
 
 			sceGuFinish();
-			sceGuSync(0,0);
+			sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 		}
 
 		sceDisplayWaitVblankStart();

--- a/src/samples/gu/signals/signals.c
+++ b/src/samples/gu/signals/signals.c
@@ -239,7 +239,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_CULL_FACE);
 	sceGuEnable(GU_TEXTURE_2D);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -265,7 +265,7 @@ int main(int argc, char* argv[])
 		sceGuAmbientColor(0xffffffff);
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 	}
 
 	// generate callable command-list for cube rendering
@@ -276,7 +276,7 @@ int main(int argc, char* argv[])
 		sceGuDrawArray(GU_TRIANGLES,GU_TEXTURE_32BITF|GU_COLOR_8888|GU_VERTEX_32BITF|GU_TRANSFORM_3D,12*3,0,cubeVertices);
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 	}
 
 	for(;;)
@@ -333,7 +333,7 @@ int main(int argc, char* argv[])
 		// this is done in order to stall GPU if it is ahead of CPU
 		sceGuFinish();
 #endif
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 #ifndef ENABLE_FRAMERATE
 		// wait for next frame

--- a/src/samples/gu/skinning/skinning.c
+++ b/src/samples/gu/skinning/skinning.c
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_LIGHT0);
 
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -187,7 +187,7 @@ int main(int argc, char* argv[])
 		}
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/speed/speed.c
+++ b/src/samples/gu/speed/speed.c
@@ -296,7 +296,7 @@ int main(int argc, char* argv[])
 	sceGuClutLoad(256/8,palette);
 
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(1);
@@ -413,7 +413,7 @@ int main(int argc, char* argv[])
 		blitTexture(blit_method,0,0,SCR_WIDTH,SCR_HEIGHT,0,0,strip_widths[strip_width].width);
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		// sum results and update report if more than one second has passed since last time
 

--- a/src/samples/gu/spharm/cube.c
+++ b/src/samples/gu/spharm/cube.c
@@ -152,7 +152,7 @@ int main(int argc, char* argv[])
   logo_temp2 = convertimage(logo_start,64);
 
 	// setup
-	sceGuStart(0,list);
+	sceGuStart(GU_DIRECT,list);
 	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
 	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
 	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
@@ -183,7 +183,7 @@ int main(int argc, char* argv[])
 	{
 		unsigned int x,y;
 
-		sceGuStart(0,list);
+		sceGuStart(GU_DIRECT,list);
 
 		sceGuClearColor(0);
 		sceGuClearDepth(0);

--- a/src/samples/gu/spharm/cube.c
+++ b/src/samples/gu/spharm/cube.c
@@ -170,7 +170,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_CULL_FACE);
 	//sceGuEnable(GU_STATE_TEXTURE);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(1);
@@ -236,7 +236,7 @@ int main(int argc, char* argv[])
 		sceGumRotateXYZ(&rot);
 	}
 		sceGuFinish();
-		//sceGuSync(0,0);
+		//sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
     SpharmGenTest(rendermode);
 
@@ -257,7 +257,7 @@ int main(int argc, char* argv[])
     }
     buttonsold = pad.Buttons;
 
-    sceGuSync(0,0);
+    sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
     sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();
 	}

--- a/src/samples/gu/spharm/spharm.c
+++ b/src/samples/gu/spharm/spharm.c
@@ -560,7 +560,7 @@ void SpharmGenTest(int rendermode)
 
 
   // Start list
-  sceGuStart(0,(unsigned int *)spharmlist);
+  sceGuStart(GU_DIRECT,(unsigned int *)spharmlist);
 
   set_rendermode(rendermode,&color);
 

--- a/src/samples/gu/splinesurface/splinesurface.c
+++ b/src/samples/gu/splinesurface/splinesurface.c
@@ -230,7 +230,7 @@ int main(int argc, char* argv[])
 //	sceGuEnable(GU_CULL_FACE);
 	sceGuEnable(GU_CLIP_PLANES);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -303,7 +303,7 @@ int main(int argc, char* argv[])
 		renderSH(parametersSH);
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/sprite/sprite.c
+++ b/src/samples/gu/sprite/sprite.c
@@ -114,7 +114,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_CULL_FACE);
 	sceGuEnable(GU_TEXTURE_2D);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -181,7 +181,7 @@ int main(int argc, char* argv[])
 		// wait for next frame
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/text/main.c
+++ b/src/samples/gu/text/main.c
@@ -174,7 +174,7 @@ int main(int argc, char** argv) {
 	sceGuTexWrap(GU_REPEAT, GU_REPEAT);
 	sceGuTexFilter(GU_NEAREST, GU_NEAREST);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 	sceGuDisplay(GU_TRUE);
 
 	while(1) {
@@ -211,7 +211,7 @@ int main(int argc, char** argv) {
 		drawString("Hello World from pspdev", 0, 224, c, 0);
 
 		sceGuFinish();
-		sceGuSync(0, 0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		sceDisplayWaitVblankStart();
 		sceGuSwapBuffers();

--- a/src/samples/gu/timing/timing.c
+++ b/src/samples/gu/timing/timing.c
@@ -199,7 +199,7 @@ int main(int argc, char** argv) {
 	sceGuDisable(GU_TEXTURE_2D);
 	sceGuSetCallback(GU_CALLBACK_SIGNAL, gucallback);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -277,7 +277,7 @@ int main(int argc, char** argv) {
 				break;
 		}
 		sceGuFinish();
-		sceGuSync(0, 0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		pspDebugScreenSetOffset((int)frameBuffer);
 		pspDebugScreenSetXY(0,0);

--- a/src/samples/gu/vertex/vertex.c
+++ b/src/samples/gu/vertex/vertex.c
@@ -234,7 +234,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_CLIP_PLANES);
 
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -560,7 +560,7 @@ int main(int argc, char* argv[])
 		sceGumLoadIdentity();
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		// draw cube
 
@@ -575,7 +575,7 @@ int main(int argc, char* argv[])
 		u64 tick1,tick2;
 		sceRtcGetCurrentTick(&tick1);
 		sceGuSendList(GU_TAIL,list,&tempGeContext);
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 		sceRtcGetCurrentTick(&tick2);
 
 		// rescale number of batches if they rendered faster/slower than threshold

--- a/src/samples/gu/zbufferfog/zbufferfog.c
+++ b/src/samples/gu/zbufferfog/zbufferfog.c
@@ -136,7 +136,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_CULL_FACE);
 	sceGuEnable(GU_CLIP_PLANES);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -235,7 +235,7 @@ int main(int argc, char* argv[])
 		sceGuDepthMask(0);	
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		pspDebugScreenSetOffset((int)fbp0);
 		pspDebugScreenSetXY(0,0);

--- a/src/samples/savedata/utility/main.c
+++ b/src/samples/savedata/utility/main.c
@@ -156,7 +156,7 @@ static void SetupGu()
     sceGuEnable(GU_CULL_FACE);
     sceGuEnable(GU_CLIP_PLANES);
     sceGuFinish();
-    sceGuSync(0,0);
+    sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
     
     sceDisplayWaitVblankStart();
     sceGuDisplay(GU_TRUE);
@@ -195,7 +195,7 @@ static void DrawStuff(void)
     sceGumDrawArray(GU_TRIANGLES,GU_TEXTURE_32BITF|GU_COLOR_8888|GU_VERTEX_32BITF|GU_TRANSFORM_3D,12*3,0,vertices);
     
     sceGuFinish();
-    sceGuSync(0,0);
+    sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
     val ++;
 }

--- a/src/samples/utility/gamesharing/main.c
+++ b/src/samples/utility/gamesharing/main.c
@@ -145,7 +145,7 @@ static void setupGu()
     	sceGuEnable(GU_CULL_FACE);
     	sceGuEnable(GU_CLIP_PLANES);
     	sceGuFinish();
-    	sceGuSync(0,0);
+    	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
     	sceDisplayWaitVblankStart();
     	sceGuDisplay(GU_TRUE);
@@ -179,7 +179,7 @@ static void drawStuff(void)
 	sceGumDrawArray(GU_TRIANGLES, GU_COLOR_8888|GU_VERTEX_32BITF|GU_TRANSFORM_3D, 12*3, 0, vertices);
 
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 	
 	val++;
 }

--- a/src/samples/utility/htmlviewer/main.c
+++ b/src/samples/utility/htmlviewer/main.c
@@ -72,7 +72,7 @@ void setupGu(void)
 	sceGuClearStencil(0);
 
 	sceGuFinish();
-	sceGuSync(0, 0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 	
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
@@ -83,7 +83,7 @@ void draw()
 	sceGuStart(GU_DIRECT, list);
 	sceGuClear(GU_COLOR_BUFFER_BIT|GU_STENCIL_BUFFER_BIT|GU_DEPTH_BUFFER_BIT);
 	sceGuFinish();
-	sceGuSync(0, 0);	
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 }
 
 void loadNetModules()

--- a/src/samples/utility/msgdialog/main.c
+++ b/src/samples/utility/msgdialog/main.c
@@ -143,7 +143,7 @@ static void SetupGu()
     sceGuEnable(GU_CULL_FACE);
     sceGuEnable(GU_CLIP_PLANES);
     sceGuFinish();
-    sceGuSync(0,0);
+    sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
     
     sceDisplayWaitVblankStart();
     sceGuDisplay(GU_TRUE);
@@ -185,7 +185,7 @@ static void DrawStuff(void)
     sceGumDrawArray(GU_TRIANGLES,GU_TEXTURE_32BITF|GU_COLOR_8888|GU_VERTEX_32BITF|GU_TRANSFORM_3D,12*3,0,vertices);
     
     sceGuFinish();
-    sceGuSync(0,0);
+    sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
     val ++;
 }

--- a/src/samples/utility/netdialog/main.c
+++ b/src/samples/utility/netdialog/main.c
@@ -150,7 +150,7 @@ static void setupGu()
     	sceGuEnable(GU_CULL_FACE);
     	sceGuEnable(GU_CLIP_PLANES);
     	sceGuFinish();
-    	sceGuSync(0,0);
+    	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
     	sceDisplayWaitVblankStart();
     	sceGuDisplay(GU_TRUE);
@@ -184,7 +184,7 @@ static void drawStuff(void)
 	sceGumDrawArray(GU_TRIANGLES, GU_COLOR_8888|GU_VERTEX_32BITF|GU_TRANSFORM_3D, 12*3, 0, vertices);
 
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 	
 	val++;
 }

--- a/src/samples/utility/osk/main.c
+++ b/src/samples/utility/osk/main.c
@@ -71,7 +71,7 @@ int main(int argc, char* argv[])
 	sceGuEnable(GU_TEXTURE_2D);
 	sceGuEnable(GU_CLIP_PLANES);
 	sceGuFinish();
-	sceGuSync(0,0);
+	sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 	sceDisplayWaitVblankStart();
 	sceGuDisplay(GU_TRUE);
 	
@@ -144,7 +144,7 @@ int main(int argc, char* argv[])
 		sceGuClear(GU_COLOR_BUFFER_BIT|GU_DEPTH_BUFFER_BIT);
 
 		sceGuFinish();
-		sceGuSync(0,0);
+		sceGuSync(GU_SYNC_FINISH, GU_SYNC_WHAT_DONE);
 
 		switch(sceUtilityOskGetStatus())
 		{


### PR DESCRIPTION
## Description

This PR does: 
- It removes some remaining magic numbers from `sceGu` functions, and instead uses the macro defined.
- It also creates a funnel for the `sceGuFinishId` function.
- Replace in all the repo the magic numbers for `sceGuSync` and `sceGuStart`