### PR TITLE
add Code of Conduct in generated documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -934,6 +934,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = "README.md" \
+                         CODE_OF_CONDUCT.md \
                          src
 
 # This tag can be used to specify the character encoding of the source files


### PR DESCRIPTION
The Code of Conduct (CoC) was not included in the documentation generated by Doxyfile. With this patch, the CoC is included, the link in the `index.html` file exists and this warning is fixed:

```
[...]README.md:160: warning: unable to resolve reference to '/home/stephane/src/pspsdk/CODE_OF_CONDUCT.md' for \ref command
```

However, I'm not sure it's the expected behavior: CoC is not code so perhaps you don't want it to be listed in the SDK documentation. In such case, I can modify the patch so the CoC file will be excluded from the documentation by the `Doxyfile` and the warning will still be fixed.

What do you think about it?