### PR TITLE
clean: remove unused macros

### DIFF
--- a/src/samples/gu/blend/blend.c
+++ b/src/samples/gu/blend/blend.c
@@ -45,12 +45,6 @@ struct BlendState
 #define SCR_WIDTH (480)
 #define SCR_HEIGHT (272)
 
-#define NUM_SLICES 128
-#define NUM_ROWS 128
-#define RING_SIZE 2.0f
-#define RING_RADIUS 1.0f
-#define SPRITE_SIZE 0.025f
-
 unsigned int __attribute__((aligned(16))) clut256[256];
 unsigned char __attribute__((aligned(16))) tex256[256*256];
 

--- a/src/samples/gu/clut/clut.c
+++ b/src/samples/gu/clut/clut.c
@@ -38,12 +38,6 @@ int SetupCallbacks();
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
 #define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
-#define NUM_SLICES 128
-#define NUM_ROWS 128
-#define RING_SIZE 2.0f
-#define RING_RADIUS 1.0f
-#define SPRITE_SIZE 0.025f
-
 unsigned int colors[8] = 
 {
 	0xffff0000,

--- a/src/samples/gu/lines/lines.c
+++ b/src/samples/gu/lines/lines.c
@@ -33,12 +33,6 @@ struct Vertex
 #define SCR_WIDTH (480)
 #define SCR_HEIGHT (272)
 
-#define NUM_SLICES 128
-#define NUM_ROWS 128
-#define RING_SIZE 2.0f
-#define RING_RADIUS 1.0f
-#define SPRITE_SIZE 0.025f
-
 unsigned int colors[8] = 
 {
 	0xffff0000,


### PR DESCRIPTION
The macros are not used.

In `blend.c`, the values are not used except for `RING_RADIUS`: `1.0f` is used in [`sceGuTexScale()`](https://github.com/pspdev/pspsdk/blob/46482f38fd879d8cad94bc9d67557b10501d2d70/src/samples/gu/blend/blend.c#L156) call for its two parameters. However, I doubt there is a link. If you think it's the case, I can modify the PR to keep `RING_RADIUS` and use it in `sceGuTexScale()` call.