### PR TITLE
Keeps improving the `sceGu` definitions and implementation

### DIFF
--- a/src/gu/pspgu.h
+++ b/src/gu/pspgu.h
@@ -59,6 +59,7 @@ extern "C" {
 #define GU_FACE_NORMAL_REVERSE	(19)
 #define GU_PATCH_FACE		(20)
 #define GU_FRAGMENT_2X		(21)
+#define GU_MAX_STATUS		(22)
 
 /* Matrix modes */
 #define GU_PROJECTION		(0)
@@ -285,6 +286,15 @@ extern "C" {
 #define GU_SYNC_WHAT_STALL (3)
 #define GU_SYNC_WHAT_CANCEL (4)
 
+/* Call mode */
+#define GU_CALL_NORMAL (0)
+#define GU_CALL_SIGNAL (1)
+
+/* Signal models */
+#define GU_SIGNAL_WAIT (1)
+#define GU_SIGNAL_NOWAIT (2)
+#define GU_SIGNAL_PAUSE (3)
+
 /* Signals */
 #define GU_CALLBACK_SIGNAL	(1)
 #define GU_CALLBACK_FINISH	(4)
@@ -292,6 +302,10 @@ extern "C" {
 /* Signal behavior */
 #define GU_BEHAVIOR_SUSPEND (1)
 #define GU_BEHAVIOR_CONTINUE (2)
+
+/* Break mode */
+#define GU_BREAK_PAUSE (0)
+#define GU_BREAK_CANCEL (1)
 
 /* Color Macros, maps 8 bit unsigned channels into one 32-bit value */
 #define GU_ABGR(a,b,g,r)	(((a) << 24)|((b) << 16)|((g) << 8)|(r))
@@ -429,8 +443,22 @@ void sceGuInit(void);
 **/
 void sceGuTerm(void);
 
-void sceGuBreak(int a0);
-void sceGuContinue(void);
+/**
+  * Break the display list
+  *
+  * @param mode - Mode to break the display list. Valid modes are:
+  *   - GU_BREAK_PAUSE - Pause the display list
+  *   - GU_BREAK_CANCEL - Cancel drawing queue
+  * @return 0 for success, < 0 for failure
+**/
+int sceGuBreak(int mode);
+
+/**
+  * Continue the display list
+  *
+  * @return 0 for success, < 0 for failure
+**/
+int sceGuContinue(void);
 
 /**
   * Setup signal handler
@@ -962,7 +990,18 @@ void sceGuColorMaterial(int components);
 **/
 void sceGuAlphaFunc(int func, int value, int mask);
 
+/**
+  * Set the ambient light color
+  *
+  * @param color - The light color to set
+**/
 void sceGuAmbient(unsigned int color);
+
+/**
+  * Set the ambient color
+  *
+  * @param color - The color to set
+**/
 void sceGuAmbientColor(unsigned int color);
 
 /**
@@ -1244,10 +1283,10 @@ void sceGuTexLevelMode(unsigned int mode, float bias);
   *   - GU_ENVIRONMENT_MAP
   *
   * @param mode - Which mode to use
-  * @param a1 - Unknown
-  * @param a2 - Unknown
+  * @param lu - Light U
+  * @param lv - Light V
 **/
-void sceGuTexMapMode(int mode, unsigned int a1, unsigned int a2);
+void sceGuTexMapMode(int mode, unsigned int lu, unsigned int lv);
 
 /**
   * Set texture-mode parameters
@@ -1262,10 +1301,10 @@ void sceGuTexMapMode(int mode, unsigned int a1, unsigned int a2);
   *
   * @param tpsm - Which texture format to use
   * @param maxmips - Number of mipmaps to use (0-8)
-  * @param a2 - Unknown, set to 0
+  * @param mc - Multiclut on/off (0/1)
   * @param swizzle - GU_TRUE(1) to swizzle texture-reads
 **/
-void sceGuTexMode(int tpsm, int maxmips, int a2, int swizzle);
+void sceGuTexMode(int tpsm, int maxmips, int mc, int swizzle);
 
 /**
   * Set texture offset
@@ -1345,7 +1384,7 @@ void sceGuClutLoad(int num_blocks, const void* cbp);
   * @param cpsm - Which pixel format to use for the palette
   * @param shift - Shifts color index by that many bits to the right
   * @param mask - Masks the color index with this bitmask after the shift (0-0xFF)
-  * @param a3 - Unknown, set to 0
+  * @param csa - Read-out start location (16-palette units)
 **/
 void sceGuClutMode(unsigned int cpsm, unsigned int shift, unsigned int mask, unsigned int a3);
 
@@ -1410,7 +1449,12 @@ void sceGuDrawBezier(int vtype, int ucount, int vcount, const void* indices, con
 **/
 void sceGuPatchDivide(unsigned int ulevel, unsigned int vlevel);
 
-void sceGuPatchFrontFace(unsigned int a0);
+/**
+  * Set front face for patches (beziers and splines)
+  *
+  * @param mode - Desired front face mode (GU_CW | GU_CCW)
+**/
+void sceGuPatchFrontFace(unsigned int mode);
 
 /**
   * Set primitive for patches (beziers and splines)
@@ -1465,7 +1509,17 @@ void sceGuBoneMatrix(unsigned int index, const ScePspFMatrix4* matrix);
 **/
 void sceGuMorphWeight(int index, float weight);
 
-void sceGuDrawArrayN(int primitive_type, int vertex_type, int count, int a3, const void* indices, const void* vertices);
+/**
+  * Draw an array of primitives
+  *
+  * @param primitive_type - Type of primitive to draw
+  * @param vertex_type - Type of vertex to draw
+  * @param vcount - Number of vertices to draw
+  * @param primcount - Number of primitives to draw
+  * @param indices - Pointer to index buffer
+  * @param vertices - Pointer to vertex buffer
+**/
+void sceGuDrawArrayN(int primitive_type, int vertex_type, int vcount, int primcount, const void* indices, const void* vertices);
 
 /**
   * Set how the display should be set

--- a/src/gu/resetValues.c
+++ b/src/gu/resetValues.c
@@ -19,7 +19,7 @@ void resetValues()
 	gu_object_stack_depth = 0;
 
 	gu_display_on = 0;
-	gu_call_mode = 0;
+	gu_call_mode = GU_CALL_NORMAL;
 
 	gu_draw_buffer.pixel_size = 1;
 	gu_draw_buffer.frame_width = 0;

--- a/src/gu/sceGuAlphaFunc.c
+++ b/src/gu/sceGuAlphaFunc.c
@@ -8,8 +8,8 @@
 
 #include "guInternal.h"
 
-void sceGuAlphaFunc(int a0, int a1, int a2)
+void sceGuAlphaFunc(int func, int value, int mask)
 {
-	int arg = a0 | ((a1 & 0xff) << 8) | ((a2 & 0xff) << 16);
+	int arg = func | ((value & 0xff) << 8) | ((mask & 0xff) << 16);
 	sendCommandi(ALPHA_TEST, arg);
 }

--- a/src/gu/sceGuAmbient.c
+++ b/src/gu/sceGuAmbient.c
@@ -10,6 +10,6 @@
 
 void sceGuAmbient(unsigned int color)
 {
-	sendCommandi(AMBIENT_LIGHT_COLOR,(color & 0xffffff));
+	sendCommandi(AMBIENT_LIGHT_COLOR,(color));
 	sendCommandi(AMBIENT_LIGHT_ALPHA,(color >> 24));
 }

--- a/src/gu/sceGuAmbientColor.c
+++ b/src/gu/sceGuAmbientColor.c
@@ -10,6 +10,6 @@
 
 void sceGuAmbientColor(unsigned int color)
 {
-	sendCommandi(AMBIENT_COLOR, color & 0xffffff);
+	sendCommandi(AMBIENT_COLOR, color);
 	sendCommandi(AMBIENT_ALPHA, color >> 24);
 }

--- a/src/gu/sceGuBeginObject.c
+++ b/src/gu/sceGuBeginObject.c
@@ -8,7 +8,7 @@
 
 #include "guInternal.h"
 
-void sceGuBeginObject(int vertex_type, int a1, const void *indices, const void *vertices)
+void sceGuBeginObject(int vertex_type, int count, const void *indices, const void *vertices)
 {
 	if (vertex_type)
 		sendCommandi(VERTEX_TYPE, vertex_type);
@@ -16,16 +16,16 @@ void sceGuBeginObject(int vertex_type, int a1, const void *indices, const void *
 	if (indices)
 	{
 		sendCommandi(BASE, (((unsigned int)indices) >> 8) & 0xf0000);
-		sendCommandi(IADDR, ((unsigned int)indices) & 0xffffff);
+		sendCommandi(IADDR, ((unsigned int)indices));
 	}
 
 	if (vertices)
 	{
 		sendCommandi(BASE, (((unsigned int)vertices) >> 8) & 0x0f0000);
-		sendCommandi(VADDR, ((unsigned int)vertices) & 0xffffff);
+		sendCommandi(VADDR, ((unsigned int)vertices));
 	}
 
-	sendCommandi(BOUNDING_BOX, a1);
+	sendCommandi(BOUNDING_BOX, count);
 
 	// store start to new object
 

--- a/src/gu/sceGuBlendFunc.c
+++ b/src/gu/sceGuBlendFunc.c
@@ -11,6 +11,6 @@
 void sceGuBlendFunc(int op, int src, int dest, unsigned int srcfix, unsigned int destfix)
 {
 	sendCommandi(BLEND_MODE, src | (dest << 4) | (op << 8));
-	sendCommandi(BLEND_FIXED_A, srcfix & 0xffffff);
-	sendCommandi(BLEND_FIXED_B, destfix & 0xffffff);
+	sendCommandi(BLEND_FIXED_A, srcfix);
+	sendCommandi(BLEND_FIXED_B, destfix);
 }

--- a/src/gu/sceGuBreak.c
+++ b/src/gu/sceGuBreak.c
@@ -6,10 +6,10 @@
  * Copyright (c) 2005 Jesper Svennevid
  */
 
-#include "guInternal.h"
+#include "pspge.h"
 
-void sceGuBreak(int a0)
+int sceGuBreak(int mode)
 {
-	// FIXME
-	//sceGeBreak(a0,0x527a68);
+	PspGeBreakParam bParam;
+	return sceGeBreak(mode, &bParam);
 }

--- a/src/gu/sceGuCallList.c
+++ b/src/gu/sceGuCallList.c
@@ -12,7 +12,7 @@ void sceGuCallList(const void *list)
 {
 	unsigned int list_addr = (unsigned int)list;
 
-	if (gu_call_mode == 1)
+	if (gu_call_mode == GU_CALL_SIGNAL)
 	{
 		sendCommandi(SIGNAL, (list_addr >> 16) | 0x110000);
 		sendCommandi(END, list_addr & 0xffff);
@@ -21,6 +21,6 @@ void sceGuCallList(const void *list)
 	else
 	{
 		sendCommandi(BASE, (list_addr >> 8) & 0xf0000);
-		sendCommandiStall(CALL, list_addr & 0xffffff);
+		sendCommandiStall(CALL, list_addr);
 	}
 }

--- a/src/gu/sceGuClutLoad.c
+++ b/src/gu/sceGuClutLoad.c
@@ -10,7 +10,7 @@
 
 void sceGuClutLoad(int num_blocks, const void *cbp)
 {
-	sendCommandi(CLUT_BUF_PTR, ((unsigned int)cbp) & 0xffffff);
+	sendCommandi(CLUT_BUF_PTR, ((unsigned int)cbp));
 	sendCommandi(CLUT_BUF_WIDTH, (((unsigned int)cbp) >> 8) & 0xf0000);
 	sendCommandi(CLUT_LOAD, num_blocks);
 }

--- a/src/gu/sceGuClutMode.c
+++ b/src/gu/sceGuClutMode.c
@@ -8,8 +8,8 @@
 
 #include "guInternal.h"
 
-void sceGuClutMode(unsigned int cpsm, unsigned int shift, unsigned int mask, unsigned int a3)
+void sceGuClutMode(unsigned int cpsm, unsigned int shift, unsigned int mask, unsigned int csa)
 {
-	unsigned int argument = (cpsm) | (shift << 2) | (mask << 8) | (a3 << 16);
+	unsigned int argument = (cpsm) | (shift << 2) | (mask << 8) | (csa << 16);
 	sendCommandi(CLUT_FORMAT, argument);
 }

--- a/src/gu/sceGuColorFunc.c
+++ b/src/gu/sceGuColorFunc.c
@@ -11,6 +11,6 @@
 void sceGuColorFunc(int func, unsigned int color, unsigned int mask)
 {
 	sendCommandi(COLOR_TEST, func & 0x03);
-	sendCommandi(COLOR_REF, color & 0xffffff);
+	sendCommandi(COLOR_REF, color);
 	sendCommandi(COLOR_TESTMASK, mask);
 }

--- a/src/gu/sceGuColorMaterial.c
+++ b/src/gu/sceGuColorMaterial.c
@@ -8,7 +8,7 @@
 
 #include "guInternal.h"
 
-void sceGuColorMaterial(int a0)
+void sceGuColorMaterial(int components)
 {
-	sendCommandi(MATERIAL_COLOR, a0);
+	sendCommandi(MATERIAL_COLOR, components);
 }

--- a/src/gu/sceGuContinue.c
+++ b/src/gu/sceGuContinue.c
@@ -6,10 +6,9 @@
  * Copyright (c) 2005 Jesper Svennevid
  */
 
-#include "guInternal.h"
+#include "pspge.h"
 
-void sceGuContinue(void)
+int sceGuContinue(void)
 {
-	// FIXME
-	//sceGeContinue();
+	return sceGeContinue();
 }

--- a/src/gu/sceGuCopyImage.c
+++ b/src/gu/sceGuCopyImage.c
@@ -10,10 +10,10 @@
 
 void sceGuCopyImage(int psm, int sx, int sy, int width, int height, int srcw, void *src, int dx, int dy, int destw, void *dest)
 {
-	sendCommandi(TRANSFER_SRC, ((unsigned int)src) & 0xffffff);
+	sendCommandi(TRANSFER_SRC, ((unsigned int)src));
 	sendCommandi(TRANSFER_SRC_W, ((((unsigned int)src) & 0xff000000) >> 8) | srcw);
 	sendCommandi(TRANSFER_SRC_OFFSET, (sy << 10) | sx);
-	sendCommandi(TRANSFER_DST, ((unsigned int)dest) & 0xffffff);
+	sendCommandi(TRANSFER_DST, ((unsigned int)dest));
 	sendCommandi(TRANSFER_DST_W, ((((unsigned int)dest) & 0xff000000) >> 8) | destw);
 	sendCommandi(TRANSFER_DST_OFFSET, (dy << 10) | dx);
 	sendCommandi(TRANSFER_SIZE, ((height - 1) << 10) | (width - 1));

--- a/src/gu/sceGuDepthBuffer.c
+++ b/src/gu/sceGuDepthBuffer.c
@@ -15,6 +15,6 @@ void sceGuDepthBuffer(void *zbp, int zbw)
 	if (!gu_draw_buffer.depth_width || (gu_draw_buffer.depth_width != zbw))
 		gu_draw_buffer.depth_width = zbw;
 
-	sendCommandi(Z_BUF_PTR, ((unsigned int)zbp) & 0xffffff);
+	sendCommandi(Z_BUF_PTR, ((unsigned int)zbp));
 	sendCommandi(Z_BUF_WIDTH, ((((unsigned int)zbp) & 0xff000000) >> 8) | zbw);
 }

--- a/src/gu/sceGuDrawArray.c
+++ b/src/gu/sceGuDrawArray.c
@@ -16,13 +16,13 @@ void sceGuDrawArray(int prim, int vtype, int count, const void *indices, const v
   if (indices)
   {
     sendCommandi(BASE, (((unsigned int)indices) >> 8) & 0xf0000);
-    sendCommandi(IADDR, ((unsigned int)indices) & 0xffffff);
+    sendCommandi(IADDR, ((unsigned int)indices));
   }
 
   if (vertices)
   {
     sendCommandi(BASE, (((unsigned int)vertices) >> 8) & 0xf0000);
-    sendCommandi(VADDR, ((unsigned int)vertices) & 0xffffff);
+    sendCommandi(VADDR, ((unsigned int)vertices));
   }
 
   sendCommandiStall(PRIM, (prim << 16) | count);

--- a/src/gu/sceGuDrawArrayN.c
+++ b/src/gu/sceGuDrawArrayN.c
@@ -8,7 +8,7 @@
 
 #include "guInternal.h"
 
-void sceGuDrawArrayN(int primitive_type, int vertex_type, int count, int a3, const void *indices, const void *vertices)
+void sceGuDrawArrayN(int primitive_type, int vertex_type, int vcount, int primcount, const void *indices, const void *vertices)
 {
 	if (vertex_type)
 		sendCommandi(VERTEX_TYPE, vertex_type);
@@ -16,21 +16,21 @@ void sceGuDrawArrayN(int primitive_type, int vertex_type, int count, int a3, con
 	if (indices)
 	{
 		sendCommandi(BASE, (((unsigned int)indices) >> 8) & 0xf0000);
-		sendCommandi(IADDR, ((unsigned int)indices) & 0xffffff);
+		sendCommandi(IADDR, (unsigned int)indices);
 	}
 
 	if (vertices)
 	{
 		sendCommandi(BASE, (((unsigned int)vertices) >> 8) & 0xf0000);
-		sendCommandi(VADDR, ((unsigned int)vertices) & 0xffffff);
+		sendCommandi(VADDR, (unsigned int)vertices);
 	}
 
-	if (a3 > 0)
+	if (primcount > 0)
 	{
-		// TODO: not sure about this loop, might be off. review
 		int i;
-		for (i = a3 - 1; i > 0; --i)
-			sendCommandi(PRIM, (primitive_type << 16) | count);
-		sendCommandiStall(PRIM, (primitive_type << 16) | count);
+		for (i = 0; i < primcount; i++)
+			sendCommandi(PRIM, (primitive_type << 16) | vcount);
+
+		sendCommandiStall(PRIM, (primitive_type << 16) | vcount);
 	}
 }

--- a/src/gu/sceGuDrawBezier.c
+++ b/src/gu/sceGuDrawBezier.c
@@ -16,13 +16,13 @@ void sceGuDrawBezier(int vertex_type, int ucount, int vcount, const void *indice
   if (indices)
   {
     sendCommandi(BASE, (((unsigned int)indices) >> 8) & 0xf0000);
-    sendCommandi(IADDR, ((unsigned int)indices) & 0xffffff);
+    sendCommandi(IADDR, (unsigned int)indices);
   }
 
   if (vertices)
   {
     sendCommandi(BASE, (((unsigned int)vertices) >> 8) & 0xf0000);
-    sendCommandi(VADDR, ((unsigned int)vertices) & 0xffffff);
+    sendCommandi(VADDR, (unsigned int)vertices);
   }
 
   sendCommandi(BEZIER, (vcount << 8) | ucount);

--- a/src/gu/sceGuDrawBuffer.c
+++ b/src/gu/sceGuDrawBuffer.c
@@ -21,8 +21,8 @@ void sceGuDrawBuffer(int psm, void *fbp, int frame_width)
 		gu_draw_buffer.depth_width = frame_width;
 
 	sendCommandi(FRAMEBUF_PIX_FORMAT, psm);
-	sendCommandi(FRAME_BUF_PTR, ((unsigned int)gu_draw_buffer.frame_buffer) & 0xffffff);
+	sendCommandi(FRAME_BUF_PTR, (unsigned int)gu_draw_buffer.frame_buffer);
 	sendCommandi(FRAME_BUF_WIDTH, ((((unsigned int)gu_draw_buffer.frame_buffer) & 0xff000000) >> 8) | gu_draw_buffer.frame_width);
-	sendCommandi(Z_BUF_PTR, ((unsigned int)gu_draw_buffer.depth_buffer) & 0xffffff);
+	sendCommandi(Z_BUF_PTR, (unsigned int)gu_draw_buffer.depth_buffer);
 	sendCommandi(Z_BUF_WIDTH, ((((unsigned int)gu_draw_buffer.depth_buffer) & 0xff000000) >> 8) | gu_draw_buffer.depth_width);
 }

--- a/src/gu/sceGuDrawBufferList.c
+++ b/src/gu/sceGuDrawBufferList.c
@@ -11,6 +11,6 @@
 void sceGuDrawBufferList(int psm, void *fbp, int fbw)
 {
 	sendCommandi(FRAMEBUF_PIX_FORMAT, psm);
-	sendCommandi(FRAME_BUF_PTR, ((unsigned int)fbp) & 0xffffff);
+	sendCommandi(FRAME_BUF_PTR, (unsigned int)fbp);
 	sendCommandi(FRAME_BUF_WIDTH, ((((unsigned int)fbp) & 0xff000000) >> 8) | fbw);
 }

--- a/src/gu/sceGuDrawSpline.c
+++ b/src/gu/sceGuDrawSpline.c
@@ -16,13 +16,13 @@ void sceGuDrawSpline(int vertex_type, int ucount, int vcount, int uedge, int ved
   if (indices)
   {
     sendCommandi(BASE, (((unsigned int)indices) >> 8) & 0xf0000);
-    sendCommandi(IADDR, ((unsigned int)indices) & 0xffffff);
+    sendCommandi(IADDR, (unsigned int)indices);
   }
 
   if (vertices)
   {
     sendCommandi(BASE, (((unsigned int)vertices) >> 8) & 0xf0000);
-    sendCommandi(VADDR, ((unsigned int)vertices) & 0xffffff);
+    sendCommandi(VADDR, (unsigned int)vertices);
   }
 
   sendCommandi(SPLINE, (vedge << 18) | (uedge << 16) | (vcount << 8) | ucount);

--- a/src/gu/sceGuEndObject.c
+++ b/src/gu/sceGuEndObject.c
@@ -16,7 +16,7 @@ void sceGuEndObject(void)
 	gu_list->current = gu_object_stack[gu_object_stack_depth - 1];
 
 	sendCommandi(BASE, (((unsigned int)current) >> 8) & 0xf0000);
-	sendCommandi(BJUMP, ((unsigned int)current) & 0xffffff);
+	sendCommandi(BJUMP, (unsigned int)current);
 	gu_list->current = current;
 
 	gu_object_stack_depth--;

--- a/src/gu/sceGuFinish.c
+++ b/src/gu/sceGuFinish.c
@@ -22,7 +22,7 @@ int sceGuFinishId(unsigned int id)
 
 	case GU_CALL:
 	{
-		if (gu_call_mode == 1)
+		if (gu_call_mode == GU_CALL_SIGNAL)
 		{
 			sendCommandi(SIGNAL, 0x120000);
 			sendCommandi(END, 0);

--- a/src/gu/sceGuFog.c
+++ b/src/gu/sceGuFog.c
@@ -15,7 +15,7 @@ void sceGuFog(float near, float far, unsigned int color)
 	if (distance)
 		distance = 1.0f / distance;
 
-	sendCommandi(FOG_COLOR, color & 0xffffff);
+	sendCommandi(FOG_COLOR, color);
 	sendCommandf(FOG1, far);
 	sendCommandf(FOG2, distance);
 }

--- a/src/gu/sceGuGetStatus.c
+++ b/src/gu/sceGuGetStatus.c
@@ -10,7 +10,7 @@
 
 int sceGuGetStatus(int state)
 {
-	if (state < 22)
+	if (state < GU_MAX_STATUS)
 		return (gu_states >> state) & 1;
 	return 0;
 }

--- a/src/gu/sceGuLightColor.c
+++ b/src/gu/sceGuLightColor.c
@@ -14,20 +14,20 @@ void sceGuLightColor(int light, int component, unsigned int color)
 
 	switch (component)
 	{
-		case GU_AMBIENT: sendCommandi(settings->ambient, color & 0xffffff); break;
-		case GU_DIFFUSE: sendCommandi(settings->diffuse, color & 0xffffff); break;
+		case GU_AMBIENT: sendCommandi(settings->ambient, color); break;
+		case GU_DIFFUSE: sendCommandi(settings->diffuse, color); break;
 		case GU_AMBIENT_AND_DIFFUSE:
 		{
-			sendCommandi(settings->ambient, color & 0xffffff); break;
-			sendCommandi(settings->diffuse, color & 0xffffff); break;
+			sendCommandi(settings->ambient, color); break;
+			sendCommandi(settings->diffuse, color); break;
 		}
 		break;
 		
-		case GU_SPECULAR: sendCommandi(settings->specular, color & 0xffffff); break;
+		case GU_SPECULAR: sendCommandi(settings->specular, color); break;
 		case GU_DIFFUSE_AND_SPECULAR:
 		{
-			sendCommandi(settings->diffuse, color & 0xffffff); break;
-			sendCommandi(settings->specular, color & 0xffffff); break;
+			sendCommandi(settings->diffuse, color); break;
+			sendCommandi(settings->specular, color); break;
 		}
 		break;
 	}

--- a/src/gu/sceGuMaterial.c
+++ b/src/gu/sceGuMaterial.c
@@ -10,15 +10,14 @@
 
 void sceGuMaterial(int mode, int color)
 {
-	if (mode & 0x01)
-	{
-		sendCommandi(AMBIENT_COLOR, color & 0xffffff);
+	if (mode & GU_AMBIENT) {
+		sendCommandi(AMBIENT_COLOR, color);
 		sendCommandi(AMBIENT_ALPHA, color >> 24);
 	}
 
-	if (mode & 0x02)
-		sendCommandi(MATERIAL_DIFFUSE, color & 0xffffff);
+	if (mode & GU_DIFFUSE)
+		sendCommandi(MATERIAL_DIFFUSE, color);
 
-	if (mode & 0x04)
-		sendCommandi(MATERIAL_SPECULAR, color & 0xffffff);
+	if (mode & GU_SPECULAR)
+		sendCommandi(MATERIAL_SPECULAR, color);
 }

--- a/src/gu/sceGuModelColor.c
+++ b/src/gu/sceGuModelColor.c
@@ -10,8 +10,8 @@
 
 void sceGuModelColor(unsigned int emissive, unsigned int ambient, unsigned int diffuse, unsigned int specular)
 {
-	sendCommandi(MATERIAL_EMISSIVE, emissive & 0xffffff);
-	sendCommandi(MATERIAL_DIFFUSE, diffuse & 0xffffff);
-	sendCommandi(AMBIENT_COLOR, ambient & 0xffffff);
-	sendCommandi(MATERIAL_SPECULAR, specular & 0xffffff);
+	sendCommandi(MATERIAL_EMISSIVE, emissive);
+	sendCommandi(MATERIAL_DIFFUSE, diffuse);
+	sendCommandi(AMBIENT_COLOR, ambient);
+	sendCommandi(MATERIAL_SPECULAR, specular);
 }

--- a/src/gu/sceGuMorphWeight.c
+++ b/src/gu/sceGuMorphWeight.c
@@ -8,7 +8,7 @@
 
 #include "guInternal.h"
 
-void sceGuMorphWeight(int index,float weight)
+void sceGuMorphWeight(int index, float weight)
 {
-	sendCommandf(44 + index,weight);
+	sendCommandf(MORPH_WEIGHT0 + index, weight);
 }

--- a/src/gu/sceGuPatchDivide.c
+++ b/src/gu/sceGuPatchDivide.c
@@ -8,7 +8,7 @@
 
 #include "guInternal.h"
 
-void sceGuPatchDivide(unsigned int a0, unsigned int a1)
+void sceGuPatchDivide(unsigned int ulevel, unsigned int vlevel)
 {
-	sendCommandi(PATCH_DIVISION, (a1 << 8) | a0);
+	sendCommandi(PATCH_DIVISION, (vlevel << 8) | ulevel);
 }

--- a/src/gu/sceGuPatchFrontFace.c
+++ b/src/gu/sceGuPatchFrontFace.c
@@ -8,7 +8,7 @@
 
 #include "guInternal.h"
 
-void sceGuPatchFrontFace(unsigned int a0)
+void sceGuPatchFrontFace(unsigned int mode)
 {
-	sendCommandi(PATCH_FACING, a0);
+	sendCommandi(PATCH_FACING, mode);
 }

--- a/src/gu/sceGuPixelMask.c
+++ b/src/gu/sceGuPixelMask.c
@@ -10,6 +10,6 @@
 
 void sceGuPixelMask(unsigned int mask)
 {
-	sendCommandi(MASK_COLOR, mask & 0xffffff);
+	sendCommandi(MASK_COLOR, mask);
 	sendCommandi(MASK_ALPHA, mask >> 24);
 }

--- a/src/gu/sceGuSetAllStatus.c
+++ b/src/gu/sceGuSetAllStatus.c
@@ -11,7 +11,7 @@
 void sceGuSetAllStatus(int status)
 {
 	unsigned int i;
-	for (i = 0; i < 22; ++i)
+	for (i = 0; i < GU_MAX_STATUS; ++i)
 	{
 		if ((status >> i)&1)
 			sceGuEnable(i);

--- a/src/gu/sceGuSetMatrix.c
+++ b/src/gu/sceGuSetMatrix.c
@@ -15,7 +15,7 @@ void sceGuSetMatrix(int type, const ScePspFMatrix4 *matrix)
 
 	switch (type)
 	{
-	case 0:
+	case GU_PROJECTION:
 	{
 		sendCommandf(PROJ_MATRIX_NUMBER, 0);
 
@@ -25,7 +25,7 @@ void sceGuSetMatrix(int type, const ScePspFMatrix4 *matrix)
 	}
 	break;
 
-	case 1:
+	case GU_VIEW:
 	{
 		sendCommandf(VIEW_MATRIX_NUMBER, 0);
 
@@ -38,7 +38,7 @@ void sceGuSetMatrix(int type, const ScePspFMatrix4 *matrix)
 	}
 	break;
 
-	case 2:
+	case GU_MODEL:
 	{
 		sendCommandf(WORLD_MATRIX_NUMBER, 0);
 
@@ -51,7 +51,7 @@ void sceGuSetMatrix(int type, const ScePspFMatrix4 *matrix)
 	}
 	break;
 
-	case 3:
+	case GU_TEXTURE:
 	{
 		sendCommandf(TGEN_MATRIX_NUMBER, 0);
 

--- a/src/gu/sceGuSignal.c
+++ b/src/gu/sceGuSignal.c
@@ -13,7 +13,7 @@ void sceGuSignal(int signal, int argument)
 	sendCommandi(SIGNAL, ((signal & 0xff) << 16) | (argument & 0xffff));
 	sendCommandi(END, 0);
 
-	if (signal == 3)
+	if (GU_SIGNAL_PAUSE == 3)
 	{
 		sendCommandi(FINISH, 0);
 		sendCommandi(END, 0);

--- a/src/gu/sceGuStart.c
+++ b/src/gu/sceGuStart.c
@@ -55,7 +55,7 @@ void sceGuStart(int ctype, void *list)
 
 	if (ctype == GU_DIRECT && gu_draw_buffer.frame_width != 0)
 	{
-		sendCommandi(FRAME_BUF_PTR, ((unsigned int)gu_draw_buffer.frame_buffer) & 0xffffff);
+		sendCommandi(FRAME_BUF_PTR, ((unsigned int)gu_draw_buffer.frame_buffer));
 		sendCommandi(FRAME_BUF_WIDTH, ((((unsigned int)gu_draw_buffer.frame_buffer) & 0xff000000) >> 8) | gu_draw_buffer.frame_width);
 	}
 }

--- a/src/gu/sceGuTexEnvColor.c
+++ b/src/gu/sceGuTexEnvColor.c
@@ -10,5 +10,5 @@
 
 void sceGuTexEnvColor(unsigned int color)
 {
-	sendCommandi(TEX_ENV_COLOR, color & 0xffffff);
+	sendCommandi(TEX_ENV_COLOR, color);
 }

--- a/src/gu/sceGuTexImage.c
+++ b/src/gu/sceGuTexImage.c
@@ -18,7 +18,7 @@ void sceGuTexImage(int mipmap, int width, int height, int tbw, const void *tbp)
 	GECommand texAddr = (GECommand)(TEX_ADDR0 + mipmap);
 	GECommand texBufWidth = (GECommand)(TEX_BUF_WIDTH0 + mipmap);
 	GECommand texSize = (GECommand)(TEX_SIZE0 + mipmap);
-	sendCommandi(texAddr, ((unsigned int)tbp) & 0xffffff);
+	sendCommandi(texAddr, ((unsigned int)tbp));
 	sendCommandi(texBufWidth, ((((unsigned int)tbp) >> 8) & 0x0f0000) | tbw);
 	sendCommandi(texSize, (getExp(height) << 8) | (getExp(width)));
 	sceGuTexFlush();

--- a/src/gu/sceGuTexMapMode.c
+++ b/src/gu/sceGuTexMapMode.c
@@ -8,12 +8,12 @@
 
 #include "guInternal.h"
 
-void sceGuTexMapMode(int mode, unsigned int a1, unsigned int a2)
+void sceGuTexMapMode(int mode, unsigned int lu, unsigned int lv)
 {
 	GuContext *context = &gu_contexts[gu_curr_context];
 
 	context->texture_map_mode = mode & 0x03;
 
 	sendCommandi(TEX_MAP_MODE, context->texture_proj_map_mode | (mode & 0x03));
-	sendCommandi(TEX_SHADE_MAPPING, (a2 << 8) | (a1 & 0x03));
+	sendCommandi(TEX_SHADE_MAPPING, (lu << 8) | (lv & 0x03));
 }

--- a/src/gu/sceGuTexMode.c
+++ b/src/gu/sceGuTexMode.c
@@ -8,12 +8,12 @@
 
 #include "guInternal.h"
 
-void sceGuTexMode(int tpsm, int maxmips, int a2, int swizzle)
+void sceGuTexMode(int tpsm, int maxmips, int mc, int swizzle)
 {
 	GuContext *context = &gu_contexts[gu_curr_context];
 	context->texture_mode = tpsm;
 
-	sendCommandi(TEX_MODE, (maxmips << 16) | (a2 << 8) | (swizzle));
+	sendCommandi(TEX_MODE, (maxmips << 16) | (mc << 8) | (swizzle));
 	sendCommandi(TEX_FORMAT, tpsm);
 
 	sceGuTexFlush();


### PR DESCRIPTION
## Description
This PR just keeps doing some clean-ups and tiny improvements around the `sceGu` code.

- Fix `sceGuBreak`
- Fix `sceGuContinue`
- Remove magic numbers in `sceGuDrawArrayN`
- Remove magic numbers in `sceGuMorphWeight`
- Remove magic numbers in `sceGuMaterial`
- Remove magic numbers in `sceGuSetMatrix`
- Remove magic numbers in `sceGuSignal`
- Remove unnecessary `0xffffff` as it is done by `sendCommandi`
- Improve the names of some parameters
- Create and use `GU_MAX_STATUS`

Cheers