### PR TITLE
Remove unused macros and magical values

### DIFF
--- a/src/samples/gu/beginobject/beginobject.c
+++ b/src/samples/gu/beginobject/beginobject.c
@@ -37,7 +37,6 @@ typedef struct VERT {
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 #define TORUS_SLICES 24 // numc
 #define TORUS_ROWS 24 // numt

--- a/src/samples/gu/beginobject/beginobject.c
+++ b/src/samples/gu/beginobject/beginobject.c
@@ -125,8 +125,8 @@ int main(int argc, char* argv[]) {
 
 	sceGuStart(GU_DIRECT,list);
 	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+	sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
 	sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
 	sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
 	sceGuDepthRange(0xc350,0x2710);

--- a/src/samples/gu/celshading/celshading.c
+++ b/src/samples/gu/celshading/celshading.c
@@ -117,8 +117,8 @@ int main(int argc, char* argv[]) {
 
 	sceGuStart(GU_DIRECT,list);
 	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+	sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
 	sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
 	sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
 	sceGuDepthRange(0xc350,0x2710);

--- a/src/samples/gu/celshading/celshading.c
+++ b/src/samples/gu/celshading/celshading.c
@@ -45,7 +45,6 @@ typedef struct Vx_v32f {
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 #define TORUS_SLICES 48 // numc
 #define TORUS_ROWS 48 // numt

--- a/src/samples/gu/clut/clut.c
+++ b/src/samples/gu/clut/clut.c
@@ -36,7 +36,6 @@ int SetupCallbacks();
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 unsigned int colors[8] = 
 {

--- a/src/samples/gu/envmap/envmap.c
+++ b/src/samples/gu/envmap/envmap.c
@@ -35,7 +35,6 @@ extern unsigned char env0_start[];
 #define SCR_WIDTH (480)
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
-#define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
 
 #define TORUS_SLICES 48 // numc
 #define TORUS_ROWS 48 // numt

--- a/src/samples/gu/envmap/envmap.c
+++ b/src/samples/gu/envmap/envmap.c
@@ -36,7 +36,6 @@ extern unsigned char env0_start[];
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 #define TORUS_SLICES 48 // numc
 #define TORUS_ROWS 48 // numt

--- a/src/samples/gu/integerdrawing/integerdrawing.c
+++ b/src/samples/gu/integerdrawing/integerdrawing.c
@@ -188,8 +188,8 @@ int main(int argc, char* argv[]) {
 
 	sceGuStart(GU_DIRECT,list);
 	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+	sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
 	sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
 	sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
 	sceGuDepthRange(0xc350,0x2710);

--- a/src/samples/gu/integerdrawing/integerdrawing.c
+++ b/src/samples/gu/integerdrawing/integerdrawing.c
@@ -96,7 +96,6 @@ static const unsigned int __attribute__((aligned(16))) texture[256] = {
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 typedef struct {
 	float s, t;

--- a/src/samples/gu/morph/morph.c
+++ b/src/samples/gu/morph/morph.c
@@ -48,7 +48,6 @@ int SetupCallbacks();
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 #define ROWS (64)
 #define COLS (64)

--- a/src/samples/gu/morph/morph.c
+++ b/src/samples/gu/morph/morph.c
@@ -111,8 +111,8 @@ int main(int argc, char* argv[])
 
 	sceGuStart(GU_DIRECT,list);
 	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+	sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
 	sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
 	sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
 	sceGuDepthRange(0xc350,0x2710);

--- a/src/samples/gu/morphskin/morphskin.c
+++ b/src/samples/gu/morphskin/morphskin.c
@@ -67,7 +67,6 @@ void genSkinnedMonsterCylinder( unsigned slices, unsigned rows, float length, fl
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 #define HIERARCHY_SIZE (WEIGHTS_PER_VERTEX)
 

--- a/src/samples/gu/morphskin/morphskin.c
+++ b/src/samples/gu/morphskin/morphskin.c
@@ -88,8 +88,8 @@ int main(int argc, char* argv[])
 
 	sceGuStart(GU_DIRECT,list);
 	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+	sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
 	sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
 	sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
 	sceGuDepthRange(0xc350,0x2710);

--- a/src/samples/gu/reflection/reflection.c
+++ b/src/samples/gu/reflection/reflection.c
@@ -106,7 +106,6 @@ int SetupCallbacks();
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 int main(int argc, char* argv[])
 {

--- a/src/samples/gu/reflection/reflection.c
+++ b/src/samples/gu/reflection/reflection.c
@@ -117,8 +117,8 @@ int main(int argc, char* argv[])
 
 	sceGuStart(GU_DIRECT,list);
 	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+	sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
 	sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
 	sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
 	sceGuDepthRange(0xc350,0x2710);

--- a/src/samples/gu/rendertarget/rendertarget.c
+++ b/src/samples/gu/rendertarget/rendertarget.c
@@ -126,7 +126,6 @@ void genTorus( unsigned slices, unsigned rows, float radius, float thickness,
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 void drawCube( Texture* texture, int val )
 {

--- a/src/samples/gu/shadowprojection/shadowprojection.c
+++ b/src/samples/gu/shadowprojection/shadowprojection.c
@@ -78,7 +78,6 @@ void genTorus( unsigned slices, unsigned rows, float radius, float thickness,
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 typedef struct Geometry
 {

--- a/src/samples/gu/signals/signals.c
+++ b/src/samples/gu/signals/signals.c
@@ -123,7 +123,6 @@ void myFinishHandler(int id);
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 #define NUM_SLICES (128)
 #define NUM_ROWS (128*4)

--- a/src/samples/gu/signals/signals.c
+++ b/src/samples/gu/signals/signals.c
@@ -222,8 +222,8 @@ int main(int argc, char* argv[])
 	// setup GU
 	sceGuStart(GU_DIRECT,list);
 	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+	sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
 	sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
 	sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
 	sceGuDepthRange(0xc350,0x2710);

--- a/src/samples/gu/skinning/skinning.c
+++ b/src/samples/gu/skinning/skinning.c
@@ -60,7 +60,6 @@ void genSkinnedCylinder( unsigned slices, unsigned rows, float length, float rad
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 #define HIERARCHY_SIZE (WEIGHTS_PER_VERTEX)
 

--- a/src/samples/gu/skinning/skinning.c
+++ b/src/samples/gu/skinning/skinning.c
@@ -81,8 +81,8 @@ int main(int argc, char* argv[])
 
 	sceGuStart(GU_DIRECT,list);
 	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+	sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
 	sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
 	sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
 	sceGuDepthRange(0xc350,0x2710);

--- a/src/samples/gu/spharm/cube.c
+++ b/src/samples/gu/spharm/cube.c
@@ -120,7 +120,6 @@ extern unsigned char logo_start[];
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 unsigned char *logo_temp2;
 

--- a/src/samples/gu/spharm/cube.c
+++ b/src/samples/gu/spharm/cube.c
@@ -153,8 +153,8 @@ int main(int argc, char* argv[])
 	// setup
 	sceGuStart(GU_DIRECT,list);
 	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+	sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
 	sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
 	sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
 	sceGuDepthRange(0xc350,0x2710);//0xc350=50000  0x2710=10000

--- a/src/samples/gu/text/main.c
+++ b/src/samples/gu/text/main.c
@@ -72,7 +72,6 @@ static int fontwidthtab[128] = {
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4)
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2)
 
 int exit_callback(int arg1, int arg2, void *common) {
 	sceKernelExitGame();

--- a/src/samples/gu/text/main.c
+++ b/src/samples/gu/text/main.c
@@ -152,8 +152,8 @@ int main(int argc, char** argv) {
 	sceGuInit();
 	sceGuStart(GU_DIRECT, list);
 	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+	sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
 	sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
 	sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
 	sceGuDepthRange(0xc350,0x2710);

--- a/src/samples/gu/timing/timing.c
+++ b/src/samples/gu/timing/timing.c
@@ -55,7 +55,6 @@ int SetupCallbacks();
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 void buildIndexedTorus() {
 	const float thickness = TORUS_ORADIUS - TORUS_IRADIUS;

--- a/src/samples/savedata/utility/main.c
+++ b/src/samples/savedata/utility/main.c
@@ -37,7 +37,6 @@ PSP_HEAP_SIZE_KB(20480);
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 #define DATABUFFLEN   0x20
 

--- a/src/samples/savedata/utility/main.c
+++ b/src/samples/savedata/utility/main.c
@@ -141,8 +141,8 @@ static void SetupGu()
 
     sceGuStart(GU_DIRECT,list);
     sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-    sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-    sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+    sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+    sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
     sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
     sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
     sceGuDepthRange(0xc350,0x2710);

--- a/src/samples/utility/gamesharing/main.c
+++ b/src/samples/utility/gamesharing/main.c
@@ -123,7 +123,6 @@ struct Vertex __attribute__((aligned(16))) vertices[12*3] =
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4)
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2)
 
 static void setupGu()
 {

--- a/src/samples/utility/gamesharing/main.c
+++ b/src/samples/utility/gamesharing/main.c
@@ -130,8 +130,8 @@ static void setupGu()
 
     	sceGuStart(GU_DIRECT,list);
     	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-    	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-    	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+    	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+    	sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
     	sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
     	sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
     	sceGuDepthRange(0xc350,0x2710);

--- a/src/samples/utility/msgdialog/main.c
+++ b/src/samples/utility/msgdialog/main.c
@@ -128,8 +128,8 @@ static void SetupGu()
 
     sceGuStart(GU_DIRECT,list);
     sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-    sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-    sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+    sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+    sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
     sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
     sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
     sceGuDepthRange(0xc350,0x2710);

--- a/src/samples/utility/msgdialog/main.c
+++ b/src/samples/utility/msgdialog/main.c
@@ -121,7 +121,6 @@ struct Vertex __attribute__((aligned(16))) vertices[12*3] =
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4) /* change this if you change to another screenmode */
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2) /* zbuffer seems to be 16-bit? */
 
 static void SetupGu()
 {

--- a/src/samples/utility/netdialog/main.c
+++ b/src/samples/utility/netdialog/main.c
@@ -128,7 +128,6 @@ struct Vertex __attribute__((aligned(16))) vertices[12*3] =
 #define SCR_HEIGHT (272)
 #define PIXEL_SIZE (4)
 #define FRAME_SIZE (BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE (BUF_WIDTH SCR_HEIGHT * 2)
 
 static void setupGu()
 {

--- a/src/samples/utility/netdialog/main.c
+++ b/src/samples/utility/netdialog/main.c
@@ -135,8 +135,8 @@ static void setupGu()
 
     	sceGuStart(GU_DIRECT,list);
     	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-    	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-    	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+    	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+    	sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
     	sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
     	sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
     	sceGuDepthRange(0xc350,0x2710);

--- a/src/samples/utility/osk/main.c
+++ b/src/samples/utility/osk/main.c
@@ -44,7 +44,6 @@ static unsigned int __attribute__((aligned(16))) list[262144];
 #define SCR_HEIGHT	(272)
 #define PIXEL_SIZE	(4)
 #define FRAME_SIZE	(BUF_WIDTH * SCR_HEIGHT * PIXEL_SIZE)
-#define ZBUF_SIZE	(BUF_WIDTH SCR_HEIGHT * 2)
 
 #define NUM_INPUT_FIELDS	(3)
 #define TEXT_LENGTH			(128)

--- a/src/samples/utility/osk/main.c
+++ b/src/samples/utility/osk/main.c
@@ -55,8 +55,8 @@ int main(int argc, char* argv[])
 	sceGuInit();
 	sceGuStart(GU_DIRECT,list);
 	sceGuDrawBuffer(GU_PSM_8888,(void*)0,BUF_WIDTH);
-	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)0x88000,BUF_WIDTH);
-	sceGuDepthBuffer((void*)0x110000,BUF_WIDTH);
+	sceGuDispBuffer(SCR_WIDTH,SCR_HEIGHT,(void*)FRAME_SIZE,BUF_WIDTH);
+	sceGuDepthBuffer((void*)(FRAME_SIZE*2),BUF_WIDTH);
 	sceGuOffset(2048 - (SCR_WIDTH/2),2048 - (SCR_HEIGHT/2));
 	sceGuViewport(2048,2048,SCR_WIDTH,SCR_HEIGHT);
 	sceGuDepthRange(0xc350,0x2710);


### PR DESCRIPTION
The PR cleans some `samples/` examples.

There are others hardcoded values (`0x44000`, `0x88000` `0x110000`), which seem to be linked to the same macros but I'm not sure so I did not modify them.