### PR TITLE
clean: remove unused variables

### DIFF
--- a/src/samples/gu/integerdrawing/integerdrawing.c
+++ b/src/samples/gu/integerdrawing/integerdrawing.c
@@ -223,7 +223,6 @@ int main(int argc, char* argv[]) {
 	pspDebugScreenInit();
 
 	unsigned int old = 0;
-	unsigned int flags = PSP_CTRL_CIRCLE | PSP_CTRL_CROSS;
 
 	int tex = 1;
 

--- a/src/samples/gu/morphskin/morphskin.c
+++ b/src/samples/gu/morphskin/morphskin.c
@@ -268,12 +268,10 @@ void genSkinnedMonsterCylinder( unsigned slices, unsigned rows, float length, fl
 			struct MorphVertex* curr = &dstMorphVertices[i+j*rows];
 			float s = i + 0.5f;
 			float t = j;
-			float cs,ct,ss,st;
+			float ct,st;
 			float d0, d1, combinedDeform;
 
-			cs = cosf(s * (2*GU_PI)/slices);
 			ct = cosf(t * (2*GU_PI)/rows);
-			ss = sinf(s * (2*GU_PI)/slices);
 			st = sinf(t * (2*GU_PI)/rows);
 
 			curr->v[0].nx = 0;

--- a/src/samples/gu/skinning/skinning.c
+++ b/src/samples/gu/skinning/skinning.c
@@ -249,13 +249,10 @@ void genSkinnedCylinder( unsigned slices, unsigned rows, float length, float rad
 		for (i = 0; i < rows; ++i)
 		{
 			struct Vertex* curr = &dstVertices[i+j*rows];
-			float s = i + 0.5f;
 			float t = j;
-			float cs,ct,ss,st;
+			float ct,st;
 
-			cs = cosf(s * (2*GU_PI)/slices);
 			ct = cosf(t * (2*GU_PI)/rows);
-			ss = sinf(s * (2*GU_PI)/slices);
 			st = sinf(t * (2*GU_PI)/rows);
 
 			curr->nx = 0;


### PR DESCRIPTION
Fix several unused variables detected by `gcc` and displayed such as:

```
morphskin.c:270:37: warning: variable ‘ss’ set but not used [-Wunused-but-set-variable]
  270 |                         float cs,ct,ss,st;
      |                                     ^~
morphskin.c:270:31: warning: variable ‘cs’ set but not used [-Wunused-but-set-variable]
  270 |                         float cs,ct,ss,st;
      |                               ^~
```