### PR TITLE
Another `scegu` improvement

### DIFF
--- a/src/debug/scr_printf.c
+++ b/src/debug/scr_printf.c
@@ -144,7 +144,7 @@ void pspDebugScreenInitEx(void *vram_base, int mode, int setup)
    g_vram_mode = mode;
    if(setup)
    {
-	   sceDisplaySetMode(0, PSP_SCREEN_WIDTH, PSP_SCREEN_HEIGHT);
+	   sceDisplaySetMode(PSP_DISPLAY_MODE_LCD, PSP_SCREEN_WIDTH, PSP_SCREEN_HEIGHT);
 	   sceDisplaySetFrameBuf((void *) g_vram_base, PSP_LINE_SIZE, mode, 1);
    }
    clear_screen(bg_col);

--- a/src/display/pspdisplay.h
+++ b/src/display/pspdisplay.h
@@ -41,6 +41,15 @@ enum PspDisplaySetBufSync {
 #define PSP_DISPLAY_SETBUF_IMMEDIATE PSP_DISPLAY_SETBUF_NEXTHSYNC
 #define PSP_DISPLAY_SETBUF_NEXTFRAME PSP_DISPLAY_SETBUF_NEXTVSYNC
 
+enum PspDisplayMode
+{
+	/** LCD MAX 480x272 at 59.94005995 Hz */
+	PSP_DISPLAY_MODE_LCD = 0,
+	/** VESA VGA MAX 640x480 at 59.94047618Hz */
+	PSP_DISPLAY_MODE_VESA1A = 0x1A,
+	/** PSEUDO VGA MAX 640x480 at 59.94005995Hz*/
+	PSP_DISPLAY_MODE_PSEUDO_VGA = 0x60
+};
 enum PspDisplayErrorCodes
 {
    SCE_DISPLAY_ERROR_OK    = 0,
@@ -54,13 +63,17 @@ enum PspDisplayErrorCodes
  *
  * @par Example1:
  * @code
+ * int mode = PSP_DISPLAY_MODE_LCD;
+ * int width = 480;
+ * int height = 272;
+ * sceDisplaySetMode(mode, width, height);
  * @endcode
  *
- * @param mode - Display mode, normally 0.
+ * @param mode - One of ::PspDisplayMode
  * @param width - Width of screen in pixels.
  * @param height - Height of screen in pixels.
  *
- * @return ???
+ * @return when error, a negative value is returned.
  */
 int sceDisplaySetMode(int mode, int width, int height);
 

--- a/src/gu/guInternal.c
+++ b/src/gu/guInternal.c
@@ -8,7 +8,6 @@
 
 #include "guInternal.h"
 
-unsigned int gu_current_frame;
 GuContext gu_contexts[3];
 int ge_list_executed[2];
 void* ge_edram_address;

--- a/src/gu/guInternal.h
+++ b/src/gu/guInternal.h
@@ -96,7 +96,6 @@ typedef struct
 	unsigned char cutoff;	 // Light cutoff
 } GuLightSettings;
 
-extern unsigned int gu_current_frame;
 extern GuContext gu_contexts[3];
 extern int ge_list_executed[2];
 extern void *ge_edram_address;

--- a/src/gu/pspgu.h
+++ b/src/gu/pspgu.h
@@ -115,6 +115,31 @@ extern "C" {
 #define GU_TRANSFORM_BITS	GU_TRANSFORM_SHIFT(1)
 /* Vertex Declarations End */
 
+/* display ON/OFF switch */
+#define GU_DISPLAY_OFF		0
+#define GU_DISPLAY_ON		1
+
+/* screen size */
+#define GU_SCR_WIDTH       480
+#define GU_SCR_HEIGHT      272
+#define GU_SCR_ASPECT      ((float)GU_SCR_WIDTH / (float)GU_SCR_HEIGHT)
+#define GU_SCR_OFFSETX     ((4096 - GU_SCR_WIDTH) / 2)
+#define GU_SCR_OFFSETY     ((4096 - GU_SCR_HEIGHT) / 2)
+
+/* Frame buffer */
+#define GU_VRAM_TOP        0x00000000
+#define GU_VRAM_WIDTH      512
+/* 16bit mode */
+#define GU_VRAM_BUFSIZE    (GU_VRAM_WIDTH*GU_SCR_HEIGHT*2)
+#define GU_VRAM_BP_0       (void *)(GU_VRAM_TOP)
+#define GU_VRAM_BP_1       (void *)(GU_VRAM_TOP+GU_VRAM_BUFSIZE)
+#define GU_VRAM_BP_2       (void *)(GU_VRAM_TOP+(GU_VRAM_BUFSIZE*2))
+/* 32bit mode */
+#define GU_VRAM_BUFSIZE32  (GU_VRAM_WIDTH*GU_SCR_HEIGHT*4)
+#define GU_VRAM_BP32_0     (void *)(GU_VRAM_TOP)
+#define GU_VRAM_BP32_1     (void *)(GU_VRAM_TOP+GU_VRAM_BUFSIZE32)
+#define GU_VRAM_BP32_2     (void *)(GU_VRAM_TOP+(GU_VRAM_BUFSIZE32*2))
+
 /* Pixel Formats */
 #define GU_PSM_5650		(0) /* Display, Texture, Palette */
 #define GU_PSM_5551		(1) /* Display, Texture, Palette */
@@ -378,8 +403,8 @@ void sceGuDrawBufferList(int psm, void* fbp, int fbw);
   * Turn display on or off
   *
   * Available states are:
-  *   - GU_TRUE (1) - Turns display on
-  *   - GU_FALSE (0) - Turns display off
+  *   - GU_DISPLAY_ON (1) - Turns display on
+  *   - GU_DISPLAY_OFF (0) - Turns display off
   *
   * @param state - Turn display on or off
   * @return State of the display prior to this call
@@ -536,8 +561,9 @@ void* sceGuGetMemory(int size);
   *
   * @param ctype - Context Type
   * @param list - Pointer to display-list (16 byte aligned)
+  * @return 0 for success, < 0 for failure
 **/
-void sceGuStart(int ctype, void* list);
+int sceGuStart(int ctype, void* list);
 
 /**
   * Finish current display list and go back to the parent context

--- a/src/gu/resetValues.c
+++ b/src/gu/resetValues.c
@@ -15,20 +15,19 @@ void _sceGuResetGlobalVariables()
 	gu_init = 0;
 
 	gu_states = 0;
-	gu_current_frame = 0;
 	gu_object_stack_depth = 0;
 
-	gu_display_on = GU_FALSE;
+	gu_display_on = GU_DISPLAY_OFF;
 	gu_call_mode = GU_CALL_NORMAL;
 
-	gu_draw_buffer.pixel_size = 1;
-	gu_draw_buffer.frame_width = 0;
+	gu_draw_buffer.pixel_size = GU_PSM_5551;
+	gu_draw_buffer.frame_width = GU_SCR_WIDTH;
 	gu_draw_buffer.frame_buffer = 0;
 	gu_draw_buffer.disp_buffer = 0;
 	gu_draw_buffer.depth_buffer = 0;
 	gu_draw_buffer.depth_width = 0;
-	gu_draw_buffer.width = 480;
-	gu_draw_buffer.height = 272;
+	gu_draw_buffer.width = GU_SCR_WIDTH;
+	gu_draw_buffer.height = GU_SCR_HEIGHT;
 
 	for (i = 0; i < 3; ++i)
 	{
@@ -58,6 +57,6 @@ void _sceGuResetGlobalVariables()
 		context->texture_mode = 0;
 	}
 
-	gu_settings.sig = 0;
-	gu_settings.fin = 0;
+	gu_settings.sig = NULL;
+	gu_settings.fin = NULL;
 }

--- a/src/gu/sceGuCallList.c
+++ b/src/gu/sceGuCallList.c
@@ -25,7 +25,8 @@ int sceGuCallList(const void *list)
 	}
 
 	res = _sceGuUpdateStallAddr();
-	if (res < 0) {
+	if (res < 0)
+	{
 		return res;
 	}
 	return 0;

--- a/src/gu/sceGuDepthBuffer.c
+++ b/src/gu/sceGuDepthBuffer.c
@@ -10,11 +10,11 @@
 
 void sceGuDepthBuffer(void *zbp, int zbw)
 {
+	sendCommandi(Z_BUF_PTR, ((unsigned int)zbp));
+	sendCommandi(Z_BUF_WIDTH, ((((unsigned int)zbp) & 0xff000000) >> 8) | zbw);
+	
 	gu_draw_buffer.depth_buffer = zbp;
 
 	if (!gu_draw_buffer.depth_width || (gu_draw_buffer.depth_width != zbw))
 		gu_draw_buffer.depth_width = zbw;
-
-	sendCommandi(Z_BUF_PTR, ((unsigned int)zbp));
-	sendCommandi(Z_BUF_WIDTH, ((((unsigned int)zbp) & 0xff000000) >> 8) | zbw);
 }

--- a/src/gu/sceGuDispBuffer.c
+++ b/src/gu/sceGuDispBuffer.c
@@ -11,12 +11,6 @@
 #include <pspkernel.h>
 #include <pspdisplay.h>
 
-static inline void drawRegion(int x, int y, int width, int height)
-{
-	sendCommandi(REGION1, (y << 10) | x);
-	sendCommandi(REGION2, (((y + height) - 1) << 10) | ((x + width) - 1));
-}
-
 void sceGuDispBuffer(int width, int height, void *dispbp, int dispbw)
 {
 	gu_draw_buffer.width = width;
@@ -26,9 +20,8 @@ void sceGuDispBuffer(int width, int height, void *dispbp, int dispbw)
 	if (!gu_draw_buffer.frame_width || (gu_draw_buffer.frame_width != dispbw))
 		gu_draw_buffer.frame_width = dispbw;
 
-	drawRegion(0, 0, gu_draw_buffer.width, gu_draw_buffer.height);
-	sceDisplaySetMode(0, gu_draw_buffer.width, gu_draw_buffer.height);
+	sceDisplaySetMode(PSP_DISPLAY_MODE_LCD, gu_draw_buffer.width, gu_draw_buffer.height);
 
-	if (gu_display_on)
+	if (gu_display_on == GU_DISPLAY_ON)
 		sceDisplaySetFrameBuf((void *)(((unsigned int)ge_edram_address) + ((unsigned int)gu_draw_buffer.disp_buffer)), dispbw, gu_draw_buffer.pixel_size, PSP_DISPLAY_SETBUF_NEXTVSYNC);
 }

--- a/src/gu/sceGuGetMemory.c
+++ b/src/gu/sceGuGetMemory.c
@@ -11,7 +11,7 @@
 #include <pspkernel.h>
 #include <pspge.h>
 
-void* sceGuGetMemory(int size)
+void *sceGuGetMemory(int size)
 {
 	// some kind of 4-byte alignment?
 	size += 3;

--- a/src/gu/sceGuInit.c
+++ b/src/gu/sceGuInit.c
@@ -18,8 +18,7 @@
 // Concrete value
 #define CV(command, value) (uint32_t)(command << 24 | value)
 
-static unsigned int __attribute__((aligned(16))) ge_init_list[] =
-	{
+static unsigned int __attribute__((aligned(16))) ge_init_list[] = {
 	ZV(NOP),
 	ZV(VADDR),
 	ZV(IADDR),

--- a/src/gu/sceGuLight.c
+++ b/src/gu/sceGuLight.c
@@ -8,7 +8,7 @@
 
 #include "guInternal.h"
 
-void sceGuLight(int light, int type, int components, const ScePspFVector3* position)
+void sceGuLight(int light, int type, int components, const ScePspFVector3 *position)
 {
 	GuLightSettings* settings = &light_settings[light];
 

--- a/src/gu/sceGuLightSpot.c
+++ b/src/gu/sceGuLightSpot.c
@@ -8,7 +8,7 @@
 
 #include "guInternal.h"
 
-void sceGuLightSpot(int light, const ScePspFVector3* direction, float exponent, float cutoff)
+void sceGuLightSpot(int light, const ScePspFVector3 *direction, float exponent, float cutoff)
 {
 	GuLightSettings* settings = &light_settings[light];
 

--- a/src/gu/sceGuSetAllStatus.c
+++ b/src/gu/sceGuSetAllStatus.c
@@ -13,7 +13,7 @@ void sceGuSetAllStatus(int status)
 	unsigned int i;
 	for (i = 0; i < GU_MAX_STATUS; ++i)
 	{
-		if ((status >> i)&1)
+		if ((status >> i) & 1)
 			sceGuEnable(i);
 		else
 			sceGuDisable(i);

--- a/src/gu/sceGuStart.c
+++ b/src/gu/sceGuStart.c
@@ -12,7 +12,7 @@
 #include <pspge.h>
 #include <pspuser.h>
 
-void sceGuStart(int ctype, void *list)
+int sceGuStart(int ctype, void *list)
 {
 	int intr;
 	GuContext *context = &gu_contexts[ctype];
@@ -34,7 +34,13 @@ void sceGuStart(int ctype, void *list)
 
 	if (ctype == GU_DIRECT)
 	{
-		ge_list_executed[0] = sceGeListEnQueue(local_list, local_list, gu_settings.ge_callback_id, NULL);
+		int res;
+		res = sceGeListEnQueue(local_list, local_list, gu_settings.ge_callback_id, NULL);
+		if (res < 0)
+		{
+			return res;
+		}
+		ge_list_executed[0] = res;
 		gu_settings.signal_offset = 0;
 	}
 
@@ -63,4 +69,6 @@ void sceGuStart(int ctype, void *list)
 		sendCommandi(FRAME_BUF_PTR, ((unsigned int)gu_draw_buffer.frame_buffer));
 		sendCommandi(FRAME_BUF_WIDTH, ((((unsigned int)gu_draw_buffer.frame_buffer) & 0xff000000) >> 8) | gu_draw_buffer.frame_width);
 	}
+
+	return 0;
 }

--- a/src/gu/sceGuSwapBuffers.c
+++ b/src/gu/sceGuSwapBuffers.c
@@ -11,24 +11,22 @@
 #include <pspkernel.h>
 #include <pspdisplay.h>
 
-void* sceGuSwapBuffers(void)
+void *sceGuSwapBuffers(void)
 {
 	if (gu_settings.swapBuffersCallback)
 	{
-		gu_settings.swapBuffersCallback(&gu_draw_buffer.disp_buffer,&gu_draw_buffer.frame_buffer);
-	} else {
-		void* temp = gu_draw_buffer.disp_buffer;
+		gu_settings.swapBuffersCallback(&gu_draw_buffer.disp_buffer, &gu_draw_buffer.frame_buffer);
+	}
+	else
+	{
+		void *temp = gu_draw_buffer.disp_buffer;
 		gu_draw_buffer.disp_buffer = gu_draw_buffer.frame_buffer;
 		gu_draw_buffer.frame_buffer = temp;
 	}
 
-	if (gu_display_on)
-		sceDisplaySetFrameBuf((void*)((unsigned int)ge_edram_address + (unsigned int)gu_draw_buffer.disp_buffer), gu_draw_buffer.frame_width, gu_draw_buffer.pixel_size, gu_settings.swapBuffersBehaviour);
+	if (gu_display_on == GU_TRUE)
+		sceDisplaySetFrameBuf((void *)((unsigned int)ge_edram_address + (unsigned int)gu_draw_buffer.disp_buffer), gu_draw_buffer.frame_width, gu_draw_buffer.pixel_size, gu_settings.swapBuffersBehaviour);
 
-	// TODO: remove this? it serves no real purpose
-	gu_current_frame ^= 1;
-
-//	return (void*)gu_settings.swapBuffersBehaviour;
 	return gu_draw_buffer.frame_buffer;
 }
 

--- a/src/gu/vram.c
+++ b/src/gu/vram.c
@@ -17,39 +17,35 @@ static unsigned int getMemorySize(unsigned int width, unsigned int height, unsig
 {
 	switch (psm)
 	{
-		case GU_PSM_T4:
-			return (width * height) >> 1;
-
-		case GU_PSM_T8:
-			return width * height;
-
-		case GU_PSM_5650:
-		case GU_PSM_5551:
-		case GU_PSM_4444:
-		case GU_PSM_T16:
-			return 2 * width * height;
-
-		case GU_PSM_8888:
-		case GU_PSM_T32:
-			return 4 * width * height;
-
-		default:
-			return 0;
+	case GU_PSM_T4:
+		return (width * height) >> 1;
+	case GU_PSM_T8:
+		return width * height;
+	case GU_PSM_5650:
+	case GU_PSM_5551:
+	case GU_PSM_4444:
+	case GU_PSM_T16:
+		return 2 * width * height;
+	case GU_PSM_8888:
+	case GU_PSM_T32:
+		return 4 * width * height;
+	default:
+		return 0;
 	}
 }
 
-void* guGetStaticVramBuffer(unsigned int width, unsigned int height, unsigned int psm)
+void *guGetStaticVramBuffer(unsigned int width, unsigned int height, unsigned int psm)
 {
-	unsigned int memSize = getMemorySize(width,height,psm);
-	staticOffset = (staticOffset + (ALIGNMENT-1)) &~ (ALIGNMENT-1);
-	void* result = (void*)staticOffset;
+	unsigned int memSize = getMemorySize(width, height, psm);
+	staticOffset = (staticOffset + (ALIGNMENT - 1)) & ~(ALIGNMENT - 1);
+	void *result = (void *)staticOffset;
 	staticOffset += memSize;
 
 	return result;
 }
 
-void* guGetStaticVramTexture(unsigned int width, unsigned int height, unsigned int psm)
+void *guGetStaticVramTexture(unsigned int width, unsigned int height, unsigned int psm)
 {
-	void* result = guGetStaticVramBuffer(width,height,psm);
-	return (void*)(((unsigned int)result) + ((unsigned int)sceGeEdramGetAddr()));
+	void *result = guGetStaticVramBuffer(width, height, psm);
+	return (void *)(((unsigned int)result) + ((unsigned int)sceGeEdramGetAddr()));
 }


### PR DESCRIPTION
## Description

This PR keeps improving and deleting magic numbers around:
- Create some macros in `pspgu.h` to avoid duplicating magic numbers everywhere.
- Define `PspDisplayMode`
- Improving documentation for `sceDisplaySetMode`
- Remove useless `gu_current_frame`
- Improve documentation and return value for `sceGuStart`
- Remove the useless `drawRegion` function in `sceGuDispBuffer`
- Some other format changes were done automatically.