### PR TITLE
Document and explicitly declare right analog stick input; display right analog stick in controller sample

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2373,7 +2373,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = __attribute__(x)=
+PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS __attribute__(x)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/src/ctrl/pspctrl.h
+++ b/src/ctrl/pspctrl.h
@@ -134,8 +134,27 @@ typedef struct SceCtrlData {
 	unsigned char 	Lx;
 	/** Y-axis value of the Analog Stick.*/
 	unsigned char 	Ly;
-	/** Reserved. */
-	unsigned char 	Rsrv[6];
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+	union {
+		struct {
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+			/** X-axis value of the right Analog Stick, valid when using DualShock 3 on PSP GO, 
+			 * 	a PS VITA system, through hardware/software hacking, or system emulation. */
+			unsigned char Rx;
+			/** Y-axis value of the right Analog Stick, valid when using DualShock 3 on PSP GO, 
+			 * 	a PS VITA system, through hardware/software hacking, or system emulation. */
+			unsigned char Ry;
+			/** Reserved bytes unused by the firmware. */
+			unsigned char Reserved[4];
+		};
+		/** 
+		 * @private
+		 * Reserved bytes. This is deprecated with the implementation of Rx and Ry and only here for backwards compatibility. 
+		 */
+		unsigned char Rsrv[6];
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+	};
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 } SceCtrlData;
 
 /** 

--- a/src/samples/controller/basic/main.c
+++ b/src/samples/controller/basic/main.c
@@ -75,8 +75,21 @@ int main(void)
 
 		sceCtrlReadBufferPositive(&pad, 1);
 
-		pspDebugScreenPrintf("Analog X = %3d ", pad.Lx);
-		pspDebugScreenPrintf("Analog Y = %3d \n", pad.Ly);
+		// 10 May 2025
+		// ---
+		// Depending on the configuration of the device the
+		// sample is being ran on, it may support a second
+		// analog stick. Known instances of this are:
+		// 1. On a PSP GO system with a connected DualShock 3
+		// 2. On a PS VITA system
+		// 3. On the PPSSPP emulator if bound in configuration settings
+		// 4. Through hardware or software modification (see https://github.com/operation-ditto)
+		// Due to these instances we should also report the second
+		// stick to the screen.
+		pspDebugScreenPrintf("L Analog X = %3d \n", pad.Lx);
+		pspDebugScreenPrintf("L Analog Y = %3d \n", pad.Ly);
+		pspDebugScreenPrintf("R Analog X = %3d \n", pad.Rx);
+		pspDebugScreenPrintf("R Analog Y = %3d \n", pad.Ry);
 
 		if (pad.Buttons != 0){
 			if (pad.Buttons & PSP_CTRL_SQUARE){


### PR DESCRIPTION
## Description

It's been known for some time now that the first two (of six) reserved bytes in the `SceCtrlData` struct are used by Sony for the right analog stick on the PSP GO (via DualShock 3) and PS VITA. However it is not intuitive and not communicated to users through the struct or from the documentation.

This PR puts the reserved bytes into a union so we can clearly define indexes zero and one as the X and Y axes for the right analog stick without causing any compatibility issues with the struct layout or existing homebrew software that calls into them via `Rsrv`. This also makes the SDK match [uofw a more nicely](https://github.com/uofw/uofw/blob/8d78362c510f686a799301e3ed54dff9c4eaf484/include/ctrl.h#L34-L39). The actual struct in the header got a bit messier because I had to hide the union from doxygen for the output to look clean, I think it is a worthy tradeoff.

I also modified the controller sample to give a bit of background behind the right stick support as well as print out the current values for the right stick.

These two changes should hopefully help in the adoption of this feature into more software :)  

---

## Visual Samples
Doxygen output:
![image](https://github.com/user-attachments/assets/669d4558-e621-4fda-94d8-d09092588f3e)

controller sample; PPSSPP:

https://github.com/user-attachments/assets/bf168d87-4127-4c23-90d6-efd1c651fdc9

controller sample; PSP:

https://github.com/user-attachments/assets/669ff53b-c560-4c87-8105-a3be08ddb841

controller sample; PS VITA:

https://github.com/user-attachments/assets/53d9d2d4-cdca-4770-8c83-7a4d2fed6dcc

