### PR TITLE
`scissor` misses `REGION1` and `REGION2` commands

### DIFF
--- a/src/gu/sceGuDisable.c
+++ b/src/gu/sceGuDisable.c
@@ -21,9 +21,14 @@ void sceGuDisable(int state)
 	case GU_SCISSOR_TEST:
 	{
 		GuContext *context = &gu_contexts[gu_curr_context];
+		int orig = 0;
+		int end = ((gu_draw_buffer.height - 1) << 10) | (gu_draw_buffer.width - 1);
+		
 		context->scissor_enable = 0;
-		sendCommandi(SCISSOR1, 0);
-		sendCommandi(SCISSOR2, ((gu_draw_buffer.height - 1) << 10) | (gu_draw_buffer.width - 1));
+		sendCommandi(SCISSOR1, orig);
+		sendCommandi(SCISSOR2, end);
+		sendCommandi(REGION1, orig);
+		sendCommandi(REGION2, end);
 	}
 	break;
 	case GU_STENCIL_TEST:

--- a/src/gu/sceGuEnable.c
+++ b/src/gu/sceGuEnable.c
@@ -21,9 +21,14 @@ void sceGuEnable(int state)
 	case GU_SCISSOR_TEST:
 	{
 		GuContext *context = &gu_contexts[gu_curr_context];
+		int orig = (context->scissor_start[1] << 10) | context->scissor_start[0];
+		int end = (context->scissor_end[1] << 10) | context->scissor_end[0];
+		
 		context->scissor_enable = 1;
-		sendCommandi(SCISSOR1, (context->scissor_start[1] << 10) | context->scissor_start[0]);
-		sendCommandi(SCISSOR2, (context->scissor_end[1] << 10) | context->scissor_end[0]);
+		sendCommandi(SCISSOR1, orig);
+		sendCommandi(SCISSOR2, end);
+		sendCommandi(REGION1, orig);
+		sendCommandi(REGION2, end);
 	}
 	break;
 	case GU_STENCIL_TEST:

--- a/src/gu/sceGuScissor.c
+++ b/src/gu/sceGuScissor.c
@@ -19,7 +19,12 @@ void sceGuScissor(int x, int y, int w, int h)
 
 	if (context->scissor_enable)
 	{
-		sendCommandi(SCISSOR1, (context->scissor_start[1] << 10) | context->scissor_start[0]);
-		sendCommandi(SCISSOR2, (context->scissor_end[1] << 10) | context->scissor_end[0]);
+		int orig = (context->scissor_start[1] << 10) | context->scissor_start[0];
+		int end = (context->scissor_end[1] << 10) | context->scissor_end[0];
+
+		sendCommandi(SCISSOR1, orig);
+		sendCommandi(SCISSOR2, end);
+		sendCommandi(REGION1, orig);
+		sendCommandi(REGION2, end);
 	}
 }


### PR DESCRIPTION
## Description
In the previous PR #286  I removed the `REGION1` and `REGION2` commands from the `sceGuDispBuffer` because it doesn't make sense (you can see it [here](https://github.com/pspdev/pspsdk/pull/286/files#diff-9a245697bd0ac20899b6e06da229bb1bd2e931265d4f3b9949c7f5dfa23d7cd0)), however, it is now required when modifying the `scissor` values.

I have noticed it because the `gu/cube` example wasn't working.

Now it is working back.
<img width="1072" alt="Screenshot 2025-05-13 at 17 42 15" src="https://github.com/user-attachments/assets/f79337e1-ce0f-47ae-858b-c326b0f62742" />

Cheers

