### PR TITLE
fix: replace a statement by an assigment

### DIFF
--- a/src/samples/gu/spharm/spharm.c
+++ b/src/samples/gu/spharm/spharm.c
@@ -637,7 +637,7 @@ void SpharmGenTest(int rendermode)
       //objtype = 6; // make sure we end up back in same spot
             } break;
     default:  // none found, so move to next one, and trigger re-gen
-      objtype == 0;
+      objtype = 0;
       inited = 0;
       break;
     }


### PR DESCRIPTION
The statement had no effect. It's in a block intended for initialization (as shown in the line 639) so an assigment was probably the intended behaviour.

The graphical output is the same with or without this patch.

Detected by a warning from gcc:

spharm.c: In function ‘SpharmGenTest’:
spharm.c:640:15: warning: statement with no effect [-Wunused-value]
  640 |       objtype == 0;
      |       ~~~~~~~~^~~~