### PR TITLE
clean: remove unused variables

### DIFF
--- a/src/samples/gu/spharm/cube.c
+++ b/src/samples/gu/spharm/cube.c
@@ -131,7 +131,6 @@ int main(int argc, char* argv[])
   SceCtrlData pad;
   unsigned int buttonsold = 0;
   int rendermode = 0;
-	int i = 0;
 	int val = 0;
 
   _DisableFPUExceptions();
@@ -180,8 +179,6 @@ int main(int argc, char* argv[])
 
 	while (!done)
 	{
-		unsigned int x,y;
-
 		sceGuStart(GU_DIRECT,list);
 
 		sceGuClearColor(0);

--- a/src/samples/gu/spharm/spharm.c
+++ b/src/samples/gu/spharm/spharm.c
@@ -375,8 +375,6 @@ extern unsigned char logo3_start[];
 unsigned char *logo2_temp;
 unsigned char *logo3_temp;
 
-static int rendertype;
-
 ScePspFVector3 columns[4] = { 
       { 0.707f, 0.707f, 0.0f },   // cos(a), sin(a), tx 
       { -0.707f, 0.707f, 0.0f },  // -sin(a), cos(a), ty 

--- a/src/samples/gu/splinesurface/splinesurface.c
+++ b/src/samples/gu/splinesurface/splinesurface.c
@@ -118,15 +118,12 @@ void setupSH()
 	struct Vertex* vtx = vertices;
 	struct Vertex* currvtx = vtx;
 
-	float du = (GU_PI*2) / GRID_WIDTH;
 	float dh = 1.0f / GRID_WIDTH;
 
 	unsigned int i,j;
 
 	for (i = 0; i < GRID_WIDTH; ++i)
 	{
-		float u = i * du;
-
 		for (j = 0; j < GRID_HEIGHT; ++j)
 		{
 			currvtx->color = hsl2rgb(i * dh, 1.0f, 0.5f);


### PR DESCRIPTION
Fix several unused variables detected by gcc and displayed such as:

morphskin.c:270:37: warning: variable ‘ss’ set but not used [-Wunused-but-set-variable]
  270 |                         float cs,ct,ss,st;
      |                                     ^~
morphskin.c:270:31: warning: variable ‘cs’ set but not used [-Wunused-but-set-variable]
  270 |                         float cs,ct,ss,st;
      |                               ^~