### PR TITLE
Fix `sceGuVIewport` with odd center values

### DIFF
--- a/src/gu/sceGuViewport.c
+++ b/src/gu/sceGuViewport.c
@@ -10,8 +10,14 @@
 
 void sceGuViewport(int cx, int cy, int width, int height)
 {
-	sendCommandf(VIEWPORT_X_SCALE, (float)(width >> 1));
-	sendCommandf(VIEWPORT_Y_SCALE, (float)((-height) >> 1));
-	sendCommandf(VIEWPORT_X_CENTER, (float)cx);
-	sendCommandf(VIEWPORT_Y_CENTER, (float)cy);
+	float sx, sy, tx, ty;
+  	sx = (float)(width)  *  0.5f;
+	sy = (float)(height) * -0.5f;
+	tx = (float)cx;
+	ty = (float)cy;
+	
+	sendCommandf(VIEWPORT_X_SCALE, sx);
+	sendCommandf(VIEWPORT_Y_SCALE, sy);
+	sendCommandf(VIEWPORT_X_CENTER, tx);
+	sendCommandf(VIEWPORT_Y_CENTER, ty);
 }


### PR DESCRIPTION
## Description
The previous logic didn't work well if the center was an `odd number` as it wouldn't be divided by 2 properly...