### PR TITLE
CMake: Fix exports.exp not being found in add_prx_module

### DIFF
--- a/src/base/AddPrxModule.cmake
+++ b/src/base/AddPrxModule.cmake
@@ -23,6 +23,7 @@ function(add_prx_module name)
           OUTPUT ${GENERATED_C_FILE}
           COMMAND psp-build-exports -b ${FILE} > ${GENERATED_C_FILE}
           DEPENDS ${FILE}
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
           COMMENT "Generating ${EXP_FILE_NAME}.c from ${EXP_FILE_NAME}.exp for target ${name}"
       )
 


### PR DESCRIPTION
Related to #309

Fixes the specific case where `add_prx_module()` fails to locate `exports.exp` when passed as a relative path.