### PR TITLE
Clarify csa parameter in sceGuClutMode documentation

### DIFF
--- a/src/gu/pspgu.h
+++ b/src/gu/pspgu.h
@@ -1412,11 +1412,13 @@ void sceGuClutLoad(int num_blocks, const void* cbp);
   *   - GU_PSM_5551
   *   - GU_PSM_4444
   *   - GU_PSM_8888
+  * 
+  * @note Final color index is computed by GE in the following way: `((pixelValue >> shift) & mask) | (csa << 4)`
   *
   * @param cpsm - Which pixel format to use for the palette
   * @param shift - Shifts color index by that many bits to the right
   * @param mask - Masks the color index with this bitmask after the shift (0-0xFF)
-  * @param csa - Read-out start location (16-palette units)
+  * @param csa - This value is shifted to the left by 4 bits and bitwise ORed with color index after applying mask
 **/
 void sceGuClutMode(unsigned int cpsm, unsigned int shift, unsigned int mask, unsigned int csa);
 


### PR DESCRIPTION
This PR clarifies behavior of csa parameter in sceGuClutMode. 

Previously it was described as `Read-out start location (16-palette units)` which implies that it offsets the palette by 16 colors while in reality csa value is shifted to the left by 4 and bitwise ORed with color index. This behavior differs from arithmetic addition for color index values larger than 15 as in that case color index bits will overlap csa bits and create results that are very different from expected 16 unit palette shift.