### PR TITLE
Clarify sceGuPixelMask documentation

### DIFF
--- a/src/gu/pspgu.h
+++ b/src/gu/pspgu.h
@@ -955,9 +955,16 @@ void sceGuClearDepth(unsigned int depth);
 void sceGuClearStencil(unsigned int stencil);
 
 /**
-  * Set mask for which bits of the pixels to write
+  * Set mask for ignoring writes to specific color channels
   *
-  * @param mask - Which bits to filter against writes
+  * @param mask - Which color channels to filter against writes 
+  * 
+  * @note This function doesn't support filtering individual bits, only entire color channels
+  * 
+  * @par Example: Do not write to blue channel
+  * @code
+  * sceGuPixelMask(0xff0000);
+  * @endcode
   *
 **/
 void sceGuPixelMask(unsigned int mask);


### PR DESCRIPTION
From my testing, `sceGuPixelMask` doesn't support filtering against individual bits, only ignoring writes to entire color channels, similar to its OpenGL counterpart.

In particular, only the 8th bit of each color component seems to be checked by GE, so a value of 128 and above will make GE ignore writes to that color channel.