### PR TITLE
Change sceGuViewport params from int to float

### DIFF
--- a/src/gu/pspgu.h
+++ b/src/gu/pspgu.h
@@ -1460,7 +1460,7 @@ void sceGuScissor(int x, int y, int w, int h);
   * @param width - Width of viewport
   * @param height - Height of viewport
 **/
-void sceGuViewport(int cx, int cy, int width, int height);
+void sceGuViewport(float cx, float cy, float width, float height);
 
 /**
   * Draw bezier surface

--- a/src/gu/sceGuViewport.c
+++ b/src/gu/sceGuViewport.c
@@ -8,16 +8,14 @@
 
 #include "guInternal.h"
 
-void sceGuViewport(int cx, int cy, int width, int height)
+void sceGuViewport(float cx, float cy, float width, float height)
 {
-	float sx, sy, tx, ty;
-  	sx = (float)(width)  *  0.5f;
-	sy = (float)(height) * -0.5f;
-	tx = (float)cx;
-	ty = (float)cy;
+	float sx, sy;
+  	sx = width  *  0.5f;
+	sy = height * -0.5f;
 	
 	sendCommandf(VIEWPORT_X_SCALE, sx);
 	sendCommandf(VIEWPORT_Y_SCALE, sy);
-	sendCommandf(VIEWPORT_X_CENTER, tx);
-	sendCommandf(VIEWPORT_Y_CENTER, ty);
+	sendCommandf(VIEWPORT_X_CENTER, cx);
+	sendCommandf(VIEWPORT_Y_CENTER, cy);
 }


### PR DESCRIPTION
This enables more flexibility in configuring viewport as you'd be able to specify it with subpixel precision. 

sceGuViewport can still be used as before, with integer parameters and behavior of existing code will remain the same, however if someone for some reason is already using sceGuViewport with float parameters, by relying on conversion from float to int to truncate fractional part, with this change behavior of such implementations will be slightly different as viewport transform may be off by up to 1 pixel. To me it seems unlikely that someone was using it in this way, or that it will have a major impact and break something, but that's not up to me to decide.