### PR TITLE
Clarify sceGuLogicalOp documentation that color logic op can be used with blending

### DIFF
--- a/src/gu/pspgu.h
+++ b/src/gu/pspgu.h
@@ -1161,6 +1161,9 @@ void sceGuFrontFace(int order);
   *   - GU_SET
   *
   * This operation only has effect if GU_COLOR_LOGIC_OP is enabled.
+  * 
+  * @note Unlike OpenGL, GE allows to enable both blending and color logic operations at the same time,
+  * in which case color blending will be computed as usual but stored in framebuffer using specified logical operation
   *
   * @param op - Operation to execute
 **/


### PR DESCRIPTION
This PR clarifies that blending is allowed to be used with color logic operations. While it is certainly not a common use case, because OpenGL disallows using both at the same time, there can be an assumption that GE functions in the same way while that's not the case.