### PR TITLE
Check if we are in the git repo (or perhaps in a tarball)

### DIFF
--- a/build-and-install.sh
+++ b/build-and-install.sh
@@ -45,8 +45,11 @@ mkdir -p $PSPDEV/share/licenses/PrxEncrypter
 cp tools/PrxEncrypter/LICENSE $PSPDEV/share/licenses/PrxEncrypter
 
 ## Store build information
-BUILD_FILE="${PSPDEV}/build.txt"
-if [[ -f "${BUILD_FILE}" ]]; then
-  sed -i'' '/^pspsdk /d' "${BUILD_FILE}"
+if [ -d .git ]; then
+  BUILD_FILE="${PSPDEV}/build.txt"
+  if [[ -f "${BUILD_FILE}" ]]; then
+    sed -i'' '/^pspsdk /d' "${BUILD_FILE}"
+  fi
+  git log -1 --format="pspsdk %H %cs %s" >> "${BUILD_FILE}"
 fi
-git log -1 --format="pspsdk %H %cs %s" >> "${BUILD_FILE}"
+


### PR DESCRIPTION
This makes the script skip the build.txt generation part if it's not in a git repo (for instance when downloading the repo as a tarball or similar).