### PR TITLE
Fixing missing function on the first start call

### DIFF
--- a/src/gu/guInternal.c
+++ b/src/gu/guInternal.c
@@ -15,6 +15,7 @@ GuSettings gu_settings;
 GuDisplayList* gu_list;
 int gu_curr_context;
 int gu_init;
+int gu_first_start;
 int gu_display_on;
 int gu_call_mode;
 int gu_states;

--- a/src/gu/guInternal.h
+++ b/src/gu/guInternal.h
@@ -79,6 +79,7 @@ extern GuSettings gu_settings;
 extern GuDisplayList *gu_list;
 extern int gu_curr_context;
 extern int gu_init;
+extern int gu_first_start;
 extern int gu_display_on;
 extern int gu_call_mode;
 extern int gu_states;

--- a/src/gu/sceGuInit.c
+++ b/src/gu/sceGuInit.c
@@ -239,6 +239,7 @@ static void sceGuResetGlobalVariables(void)
 	unsigned int i;
 
 	gu_init = 0;
+	gu_first_start = 0;
 
 	gu_states = 0;
 	gu_object_stack_depth = 0;
@@ -371,5 +372,6 @@ int sceGuInit(void)
 	gu_settings.swapBuffersBehaviour = PSP_DISPLAY_SETBUF_NEXTHSYNC;
 
 	gu_init = 1;
+	gu_first_start = 1;
 	return 0;
 }

--- a/src/gu/sceGuStart.c
+++ b/src/gu/sceGuStart.c
@@ -50,7 +50,7 @@ int sceGuStart(int ctype, void *list)
 		gu_settings.signal_offset = 0;
 	}
 
-	if (!gu_init)
+	if (gu_first_start)
 	{
 		static int dither_matrix[16] =
 			{
@@ -67,7 +67,7 @@ int sceGuStart(int ctype, void *list)
 		sceGuSpecular(1.0f);
 		sceGuTexScale(1.0f, 1.0f);
 
-		gu_init = 1;
+		gu_first_start = 0;
 	}
 
 	if (ctype == GU_DIRECT && gu_draw_buffer.frame_width != 0)

--- a/src/gu/sceGuTerm.c
+++ b/src/gu/sceGuTerm.c
@@ -22,4 +22,6 @@ void sceGuTerm(void)
 
 	sceKernelDeleteEventFlag(gu_settings.kernel_event_flag);
 	sceGeUnsetCallback(gu_settings.ge_callback_id);
+
+	gu_init = 0;
 }


### PR DESCRIPTION
## Description
This PR creates a separate variable for identifying if the first `sceGuStart` happened already; it now uses `gu_first_start`.

Cheers