### PR TITLE
Fix CMake prx exports build issue for projects building multiple prx's.

### DIFF
--- a/src/base/AddPrxModule.cmake
+++ b/src/base/AddPrxModule.cmake
@@ -16,7 +16,7 @@ function(add_prx_module name)
       get_filename_component(EXP_FILE_NAME ${FILE} NAME_WE)
 
       # Define the output .c file path
-      set(GENERATED_C_FILE ${CMAKE_BINARY_DIR}/${EXP_FILE_NAME}.c)
+      set(GENERATED_C_FILE ${CMAKE_CURRENT_BINARY_DIR}/${EXP_FILE_NAME}.c)
 
       # Add a custom command for each .exp file to generate a .c file
       add_custom_command(


### PR DESCRIPTION
Currently the generated exports.c is output to CMAKE_BINARY_DIR the top level build directory. This causes build issues in projects with multiple prx's as they end up building against an exports.c generated from another prx module. Use CMAKE_CURRENT_BINARY_DIR instead.