### PR TITLE
Add getters in pspaudiolib

### DIFF
--- a/src/audio/pspaudiolib.c
+++ b/src/audio/pspaudiolib.c
@@ -30,12 +30,25 @@ void pspAudioSetVolume(int channel, int left, int right)
   AudioStatus[channel].volumeleft  = left;
 }
 
+void pspAudioGetVolume(int channel, int *left, int *right)
+{
+  *right = AudioStatus[channel].volumeright;
+  *left = AudioStatus[channel].volumeleft;
+}
+
 void pspAudioSetChannelCallback(int channel, pspAudioCallback_t callback, void *pdata)
 {
 	volatile psp_audio_channelinfo *pci = &AudioStatus[channel];
 	pci->callback=0;
 	pci->pdata=pdata;
 	pci->callback=callback;
+}
+
+void pspAudioGetChannelCallback(int channel, pspAudioCallback_t *callback, void **pdata)
+{
+	volatile psp_audio_channelinfo *pci = &AudioStatus[channel];
+	*pdata = pci->pdata;
+	*callback = pci->callback;
 }
 
 int pspAudioOutBlocking(unsigned int channel, unsigned int vol1, unsigned int vol2, void *buf)

--- a/src/audio/pspaudiolib.h
+++ b/src/audio/pspaudiolib.h
@@ -41,7 +41,9 @@ void pspAudioEndPre();
 void pspAudioEnd();
 
 void pspAudioSetVolume(int channel, int left, int right);
+void pspAudioGetVolume(int channel, int *left, int *right);
 void pspAudioSetChannelCallback(int channel, pspAudioCallback_t callback, void *pdata);
+void pspAudioGetChannelCallback(int channel, pspAudioCallback_t *callback, void **pdata);
 int  pspAudioOutBlocking(unsigned int channel, unsigned int vol1, unsigned int vol2, void *buf);
 
 #ifdef __cplusplus


### PR DESCRIPTION
I found no other way to get the currently set callback and its data so I implemented this. I also added the volume getter for completeness.