### PR TITLE
fix pspSdkInstallNoPlainModuleCheckPatch

### DIFF
--- a/src/sdk/modulemgr_patches.c
+++ b/src/sdk/modulemgr_patches.c
@@ -82,7 +82,7 @@ int pspSdkInstallNoPlainModuleCheckPatch(void)
     u32 *addr;
     int i;
 
-    addr = (u32*) (0x80000000 | (((u32)sceKernelProbeExecutableObject & 0x03FFFFFF) << 2));
+    addr = (u32*) (0x80000000 | ((_lw((u32)sceKernelProbeExecutableObject) & 0x03FFFFFF) << 2));
     //printf("sceKernelProbeExecutableObject %p\n", addr);
     for(i = 0; i < 100; i++)
     {
@@ -93,7 +93,7 @@ int pspSdkInstallNoPlainModuleCheckPatch(void)
         }
     }
 
-    addr = (u32*) (0x80000000 | (((u32)sceKernelCheckPspConfig & 0x03FFFFFF) << 2));
+    addr = (u32*) (0x80000000 | ((_lw((u32)sceKernelCheckPspConfig) & 0x03FFFFFF) << 2));
     //printf("sceCheckPspConfig %p\n", addr);
     for(i = 0; i < 100; i++)
     {


### PR DESCRIPTION
It seems that in older versions of the SDK, sceKernelProbeExecutableObject and sceKernelCheckPspConfig were function pointers but they are now stubs, causing pspSdkInstallNoPlainModuleCheckPatch to crash.
This PR fixes it.