### PR TITLE
Fix bin2o generated elf header

### DIFF
--- a/tools/bin2o.c
+++ b/tools/bin2o.c
@@ -56,7 +56,7 @@ unsigned char elf_header[] = {
     0x00, 0x00, 0x00, 0x00,                         // e_entry
     0x00, 0x00, 0x00, 0x00,                         // e_phoff
     0x34, 0x00, 0x00, 0x00,                         // e_shoff
-    0x01, 0x40, 0x92, 0x20,                         // e_flags
+    0x01, 0x40, 0x92, 0x10,                         // e_flags
     0x34, 0x00,                                     // e_ehsize
     0x00, 0x00,                                     // e_phentsize
     0x00, 0x00,                                     // e_phnum


### PR DESCRIPTION
Fixes #362

See the following values:
https://github.com/reswitched/newlib/blob/76f6d4e21ed5b621adb75fe99a69704dca831177/include/elf/mips.h#L218-L222

---

#### Before:
```
❯ llvm-readelf -h my_file.o
ELF Header:
  Magic:   7f 45 4c 46 01 01 01 00 00 00 00 00 00 00 00 00
  Class:                             ELF32
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              REL (Relocatable file)
  Machine:                           MIPS R3000
  Version:                           0x1
  Entry point address:               0x0
  Start of program headers:          0 (bytes into file)
  Start of section headers:          52 (bytes into file)
  Flags:                             0x20924001, noreorder, eabi64, 5900, mips3
  Size of this header:               52 (bytes)
  Size of program headers:           0 (bytes)
  Number of program headers:         0
  Size of section headers:           40 (bytes)
  Number of section headers:         5
  Section header string table index: 1
```

#### After:
```
❯ llvm-readelf -h my_file.o
ELF Header:
  Magic:   7f 45 4c 46 01 01 01 00 00 00 00 00 00 00 00 00
  Class:                             ELF32
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              REL (Relocatable file)
  Machine:                           MIPS R3000
  Version:                           0x1
  Entry point address:               0x0
  Start of program headers:          0 (bytes into file)
  Start of section headers:          52 (bytes into file)
  Flags:                             0x10924001, noreorder, eabi64, 5900, mips2
  Size of this header:               52 (bytes)
  Size of program headers:           0 (bytes)
  Number of program headers:         0
  Size of section headers:           40 (bytes)
  Number of section headers:         5
  Section header string table index: 1
```
