### PR TITLE
Fix "no sceModuleInfo section found" when linking with `--gc-sections`

### DIFF
--- a/src/base/linkfile.prx.in
+++ b/src/base/linkfile.prx.in
@@ -83,7 +83,7 @@ SECTIONS
     KEEP (*(.fini))
   } =0
   /* PSP library stub functions. */
-  .sceStub.text     : { *(.sceStub.text) *(SORT(.sceStub.text.*)) }
+  .sceStub.text     : { KEEP(*(.sceStub.text)) KEEP(*(SORT(.sceStub.text.*))) }
   PROVIDE (__etext = .);
   PROVIDE (_etext = .);
   PROVIDE (etext = .);

--- a/src/base/linkfile.prx.in
+++ b/src/base/linkfile.prx.in
@@ -98,7 +98,7 @@ SECTIONS
      .rodata.sceModuleInfo section must appear before the .rodata section
      otherwise it would get absorbed into .rodata and the PSP bootloader
      would be unable to locate the module info structure. */
-  .rodata.sceModuleInfo    : { *(.rodata.sceModuleInfo) }
+  .rodata.sceModuleInfo    : { KEEP (*(.rodata.sceModuleInfo)) }
   .rodata.sceResident      : { *(.rodata.sceResident) }
   .rodata.sceNid           : { KEEP (*(.rodata.sceNid)) }
   .rodata.sceVstub         : { *(.rodata.sceVstub) *(SORT(.rodata.sceVstub.*)) }


### PR DESCRIPTION
Fixes an issue where .rodata.sceModuleInfo can be discarded when linking with `--gc-sections`, causing `psp-fixup-imports` to fail with:
```
Error, no sceModuleInfo section found
```
