### PR TITLE
Add guGetInit function

### DIFF
--- a/src/gu/pspgu.h
+++ b/src/gu/pspgu.h
@@ -477,6 +477,15 @@ int sceGuInit(void);
 void sceGuTerm(void);
 
 /**
+  * Get if the GU system has been initialized
+  *
+  * Returns 1 after sceGuInit() has been called, returns 0 otherwise or after sceGuTerm() has been called.
+  *
+  * @return Whether the GU system has been initialized or not
+**/
+int sceGuGetInit();
+
+/**
   * Break the display list
   *
   * @param mode - Mode to break the display list. Valid modes are:

--- a/src/gu/pspgu.h
+++ b/src/gu/pspgu.h
@@ -483,7 +483,7 @@ void sceGuTerm(void);
   *
   * @return Whether the GU system has been initialized or not
 **/
-int sceGuGetInit();
+int guGetInit();
 
 /**
   * Break the display list

--- a/src/gu/sceGuInit.c
+++ b/src/gu/sceGuInit.c
@@ -375,3 +375,7 @@ int sceGuInit(void)
 	gu_first_start = 1;
 	return 0;
 }
+
+int sceGuGetInit() {
+	return gu_init;
+}

--- a/src/gu/sceGuInit.c
+++ b/src/gu/sceGuInit.c
@@ -376,6 +376,6 @@ int sceGuInit(void)
 	return 0;
 }
 
-int sceGuGetInit() {
+int guGetInit() {
 	return gu_init;
 }


### PR DESCRIPTION
This function is needed to make sure we can always spawn the keyboard or notifications while SDL is being used for example, but I'm sure there are other use cases. The variable that is exposed here was already used internally a lot.