### PR TITLE
Rename PSP_SYSTEMPARAM_ID_INT_UNKNOWN to PSP_SYSTEMPARAM_ID_INT_BUTTON_SWAP

### DIFF
--- a/src/samples/utility/htmlviewer/main.c
+++ b/src/samples/utility/htmlviewer/main.c
@@ -215,7 +215,7 @@ void htmlViewerInit(char *url)
 	params.base.size = sizeof(pspUtilityHtmlViewerParam);
 	
 	sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_LANGUAGE, &params.base.language);
-	sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_UNKNOWN, &params.base.buttonSwap);
+	sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_BUTTON_SWAP, &params.base.buttonSwap);
 	
 	params.base.graphicsThread = 17;
 	params.base.accessThread = 19;

--- a/src/samples/utility/msgdialog/main.c
+++ b/src/samples/utility/msgdialog/main.c
@@ -201,7 +201,7 @@ static void ConfigureDialog(pspUtilityMsgDialogParams *dialog, size_t dialog_siz
     dialog->base.size = dialog_size;
     sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_LANGUAGE,
 				&dialog->base.language); // Prompt language
-    sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_UNKNOWN,
+    sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_BUTTON_SWAP,
 				&dialog->base.buttonSwap); // X/O button swap
 
     dialog->base.graphicsThread = 0x11;

--- a/src/samples/utility/osk/main.c
+++ b/src/samples/utility/osk/main.c
@@ -125,7 +125,7 @@ int main(int argc, char* argv[])
 	memset(&params, 0, sizeof(params));
 	params.base.size = sizeof(params);
 	sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_LANGUAGE, &params.base.language);
-	sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_UNKNOWN, &params.base.buttonSwap);
+	sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_BUTTON_SWAP, &params.base.buttonSwap);
 	params.base.graphicsThread = 17;
 	params.base.accessThread = 19;
 	params.base.fontThread = 18;

--- a/src/samples/utility/systemparam/main.c
+++ b/src/samples/utility/systemparam/main.c
@@ -141,7 +141,7 @@ void printSystemParam(int id, int iVal, char *sVal) {
 					printf("%-17s: INVALID\n", "Language");
 			}
 			break;
-		case(PSP_SYSTEMPARAM_ID_INT_UNKNOWN):
+		case(PSP_SYSTEMPARAM_ID_INT_BUTTON_SWAP):
 			printf("%-17s: %d (1 on NA PSPs and 0 on JAP PSPs, v1.5+ only)\n", "Unknown:", iVal);
 			break;
 		default:

--- a/src/utility/psputility_sysparam.h
+++ b/src/utility/psputility_sysparam.h
@@ -32,12 +32,16 @@ extern "C" {
 #define PSP_SYSTEMPARAM_ID_INT_TIMEZONE		6
 #define PSP_SYSTEMPARAM_ID_INT_DAYLIGHTSAVINGS	7
 #define PSP_SYSTEMPARAM_ID_INT_LANGUAGE		8
+
 /**
- * #9 seems to be Region or maybe X/O button swap.
- * It doesn't exist on JAP v1.0
- * is 1 on NA v1.5s
- * is 0 on JAP v1.5s
- * is read-only
+ * Whether to swap X and O depends on region
+ * 0 for O as confirm
+ * 1 for X as confirm
+ */
+#define PSP_SYSTEMPARAM_ID_INT_BUTTON_SWAP	9
+
+/**
+ * Old name of PSP_SYSTEMPARAM_ID_INT_BUTTON_SWAP for legacy compatibility
  */
 #define PSP_SYSTEMPARAM_ID_INT_UNKNOWN		9
 


### PR DESCRIPTION
I kept the old define as well for backwards compatibility, but this name should explain more clearly what it does.