### PR TITLE
Make pspsdk docs easier to generate locally

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -14,11 +14,7 @@ jobs:
 
     - name: Prepare Doxyfile
       run: |
-        sed -e 's/\$(PROJECT)/PSPSDK/' \
-            -e 's/\$(VERSION)/'`date +"%Y-%m-%d" | xargs echo -n`'/' \
-            -e 's/\$(SRCDIR)/src/g' \
-            -e 's/\$(GENERATE_LATEX)/NO/' \
-            -e 's/\$(HAVE_DOT)/YES/' \
+        sed -e 's/\$(VERSION)/'`date +"%Y-%m-%d" | xargs echo -n`'/' \
             -e 's/Helvetica/FreeSans/' \
             -i Doxyfile
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -42,7 +42,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = $(PROJECT)
+PROJECT_NAME           = PSPSDK
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -174,7 +174,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = $(SRCDIR)
+STRIP_FROM_PATH        = src
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -183,7 +183,7 @@ STRIP_FROM_PATH        = $(SRCDIR)
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = $(SRCDIR)
+STRIP_FROM_INC_PATH    = src
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -1020,7 +1020,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = $(SRCDIR)/samples
+EXAMPLE_PATH           = src/samples
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and
@@ -1911,7 +1911,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = $(GENERATE_LATEX)
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -2457,7 +2457,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: YES.
 
-HAVE_DOT               = $(HAVE_DOT)
+HAVE_DOT               = YES
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is allowed
 # to run in parallel. When set to 0 doxygen will base this on the number of

--- a/m4/ax_prog_doxygen.m4
+++ b/m4/ax_prog_doxygen.m4
@@ -266,8 +266,6 @@ m4_define([DX_loop], m4_dquote(m4_if(m4_eval(3 < m4_count($@)), 1,
           [])))dnl
 
 # Environment variables used inside doxygen.cfg:
-DX_ENV_APPEND(SRCDIR, $srcdir)
-DX_ENV_APPEND(PROJECT, $DX_PROJECT)
 DX_ENV_APPEND(VERSION, $PACKAGE_VERSION)
 
 # Doxygen itself:
@@ -277,15 +275,6 @@ DX_ARG_ABLE(doc, [generate any doxygen documentation],
             [DX_REQUIRE_PROG([DX_DOXYGEN], doxygen)
              DX_REQUIRE_PROG([DX_PERL], perl)],
             [DX_ENV_APPEND(PERL_PATH, $DX_PERL)])
-
-# Dot for graphics:
-DX_ARG_ABLE(dot, [generate graphics for doxygen documentation],
-            [DX_CHECK_DEPEND(doc, 1)],
-            [DX_CLEAR_DEPEND(doc, 1)],
-            [DX_REQUIRE_PROG([DX_DOT], dot)],
-            [DX_ENV_APPEND(HAVE_DOT, YES)
-             DX_ENV_APPEND(DOT_PATH, [`DX_DIRNAME_EXPR($DX_DOT)`])],
-            [DX_ENV_APPEND(HAVE_DOT, NO)])
 
 # Man pages generation:
 DX_ARG_ABLE(man, [generate doxygen manual pages],
@@ -353,13 +342,6 @@ DX_ARG_ABLE(pdf, [generate doxygen PDF documentation],
             [DX_REQUIRE_PROG([DX_PDFLATEX], pdflatex)
              DX_REQUIRE_PROG([DX_MAKEINDEX], makeindex)
              DX_REQUIRE_PROG([DX_EGREP], egrep)])
-
-# LaTeX generation for PS and/or PDF:
-if DX_TEST_FEATURE(ps) || DX_TEST_FEATURE(pdf); then
-    DX_ENV_APPEND(GENERATE_LATEX, YES)
-else
-    DX_ENV_APPEND(GENERATE_LATEX, NO)
-fi
 
 # Paper size for PS and/or PDF:
 AC_ARG_VAR(DOXYGEN_PAPER_SIZE,


### PR DESCRIPTION
It is a bit odd to change settings in the workflow that should be the same in both the workflow and locally.