### PR TITLE
Map UNKNOWN directly to BUTTON_SWAP

### DIFF
--- a/src/utility/psputility_sysparam.h
+++ b/src/utility/psputility_sysparam.h
@@ -43,7 +43,7 @@ extern "C" {
 /**
  * Old name of PSP_SYSTEMPARAM_ID_INT_BUTTON_SWAP for legacy compatibility
  */
-#define PSP_SYSTEMPARAM_ID_INT_UNKNOWN		9
+#define PSP_SYSTEMPARAM_ID_INT_UNKNOWN		PSP_SYSTEMPARAM_ID_INT_BUTTON_SWAP
 
 /**
  * Return values for the SystemParam functions


### PR DESCRIPTION
Since PSP_SYSTEMPARAM_ID_INT_UNKNOWN is PSP_SYSTEMPARAM_ID_INT_BUTTON_SWAP, it is a bit cleaner to connect them directly.