### PR TITLE
fix(loadcore,modulemgr_kernel): Move `sceKernelGetModuleList` and `sceKernelModuleCount` prototypes to `psploadcore.h`

### DIFF
--- a/src/kernel/psploadcore.h
+++ b/src/kernel/psploadcore.h
@@ -352,6 +352,22 @@ typedef struct SceLoadCoreExecFileInfo {
 	u32 max_seg_align; //188
 } SceLoadCoreExecFileInfo;
 
+/**
+ * Gets the current module list.
+ *
+ * @param readbufsize - The size of the read buffer.
+ * @param readbuf     - Pointer to a buffer to store the IDs
+ *
+ * @return < 0 on error.
+ */
+int sceKernelGetModuleList(int readbufsize, SceUID *readbuf);
+
+/**
+ * Get the number of loaded modules.
+ *
+ * @return The number of loaded modules.
+ */
+int sceKernelModuleCount(void);
 
 /**
  * Find a module by it's name.

--- a/src/kernel/pspmodulemgr_kernel.h
+++ b/src/kernel/pspmodulemgr_kernel.h
@@ -30,9 +30,9 @@ enum SceModuleMgrExecModes {
 	MODULE_EXEC_CMD_UNLOAD,
 };
 
-/** 
+/**
  * Structure used internally for many `sceModuleManager` module functions.
- * 
+ *
  * Also seems to be passed to `sceKernelStartThread` eventually by those internal functions.
  * */
 typedef struct {
@@ -81,7 +81,7 @@ typedef struct {
 	SceUID extern_mem_block_partition_id;
 	SceSize extern_mem_block_size;
 	u32 unk6;
-	void *block_gzip; 
+	void *block_gzip;
 	u32 unk7;
 	char secure_install_id[SCE_SECURE_INSTALL_ID_LEN];
 	SceUID extern_mem_block_id_user;
@@ -95,23 +95,6 @@ extern "C" {
 
 /** @addtogroup ModuleMgrKern Kernel Module Manager Library */
 /**@{*/
-
-/**
- * Gets the current module list.
- * 
- * @param readbufsize - The size of the read buffer.
- * @param readbuf     - Pointer to a buffer to store the IDs
- *
- * @return < 0 on error.
- */
-int sceKernelGetModuleList(int readbufsize, SceUID *readbuf);
-
-/**
- * Get the number of loaded modules.
- *
- * @return The number of loaded modules.
- */
-int sceKernelModuleCount(void);
 
 /**
  * Load a module from a buffer


### PR DESCRIPTION
Those are loaded by `LoadCoreForKernel` and not `ModuleMgrForKernel`