### PR TITLE
add dup() function

### DIFF
--- a/src/libcglue/Makefile.am
+++ b/src/libcglue/Makefile.am
@@ -30,7 +30,7 @@ GLUE_OBJS = __dummy_passwd.o __psp_heap_blockid.o __psp_free_heap.o _fork.o _wai
 	_isatty.o symlink.o truncate.o chmod.o fchmod.o pathconf.o readlink.o utime.o fchown.o _getentropy.o getpwuid.o \
 	fsync.o getpwnam.o getuid.o geteuid.o basename.o statvfs.o \
 	openat.o renameat.o fchmodat.o fstatat.o mkdirat.o faccessat.o fchownat.o linkat.o readlinkat.o unlinkat.o \
-	realpath.o gethostname.o
+	realpath.o gethostname.o dup.o
 
 INIT_OBJS = \
 	__libpthreadglue_init.o \

--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -1230,3 +1230,9 @@ int gethostname (char *__name, size_t __len) {
 	return __set_errno(EINVAL);
 }
 #endif /* F_gethostname */
+
+#ifdef F_dup
+int dup(int oldfd) {
+	return fcntl(oldfd, F_DUPFD, 0);
+}
+#endif

--- a/src/libcglue/glue.c
+++ b/src/libcglue/glue.c
@@ -1235,4 +1235,4 @@ int gethostname (char *__name, size_t __len) {
 int dup(int oldfd) {
 	return fcntl(oldfd, F_DUPFD, 0);
 }
-#endif
+#endif /* F_dup */


### PR DESCRIPTION
Tested only on PPSSPP

```c
#include <pspkernel.h>
#include <pspdebug.h>

#include <stdio.h>
#include <fcntl.h>
#include <unistd.h>
#include <errno.h>
#include <string.h>

PSP_MODULE_INFO("dup_test", 0, 1, 0);
PSP_MAIN_THREAD_ATTR(THREAD_ATTR_USER);

#define printf pspDebugScreenPrintf

#define TEST_ASSERT(cond, msg)                 \
    do {                                       \
        if (cond)                              \
            printf("[PASS] %s\n", msg);        \
        else {                                 \
            printf("[FAIL] %s\n", msg);        \
            printf("       errno=%d (%s)\n",   \
                   errno, strerror(errno));    \
        }                                      \
    } while(0)

int exit_callback(int arg1, int arg2, void *common)
{
    sceKernelExitGame();
    return 0;
}


int CallbackThread(SceSize args, void *argp)
{
    int cbid = sceKernelCreateCallback(
        "Exit Callback",
        exit_callback,
        NULL);

    sceKernelRegisterExitCallback(cbid);

    sceKernelSleepThreadCB();

    return 0;
}


int main()
{
    pspDebugScreenInit();

    int fd_orig = open("test_dup.txt", O_WRONLY | O_CREAT | O_TRUNC, 0644);
    if (fd_orig < 0) {
        perror("Failed to open file");
        return 1;
    }

    int fd_copy = dup(fd_orig);
    if (fd_copy < 0) {
        perror("dup() failed");
        close(fd_orig);
        return 1;
    }
    printf("Original FD: %d, Duplicated FD: %d\n", fd_orig, fd_copy);

    const char *msg1 = "Hello ";
    write(fd_orig, msg1, strlen(msg1));

    const char *msg2 = "World!\n";
    write(fd_copy, msg2, strlen(msg2));


    close(fd_orig);
    close(fd_copy);
    
    printf("Test complete. Check 'test_dup.txt' for 'Hello World!'\n");

    sceKernelSleepThread();

    return 0;
}

```