### PR TITLE
feat: Make all stubs weak imports

### DIFF
--- a/src/audio/sceAudio.S
+++ b/src/audio/sceAudio.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceAudio_0000
-	IMPORT_START	"sceAudio",0x40010000
+	IMPORT_START	"sceAudio",0x40090000
 #endif
 #ifdef F_sceAudio_0001
 	IMPORT_FUNC	"sceAudio",0x8C1009B2,sceAudioOutput

--- a/src/audio/sceAudio_driver.S
+++ b/src/audio/sceAudio_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceAudio_driver_0000
-	IMPORT_START	"sceAudio_driver",0x00010000
+	IMPORT_START	"sceAudio_driver",0x00090000
 #endif
 
 #ifdef F_sceAudio_driver_0001

--- a/src/ctrl/sceCtrl.S
+++ b/src/ctrl/sceCtrl.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceCtrl_0000
-	IMPORT_START	"sceCtrl",0x40010000
+	IMPORT_START	"sceCtrl",0x40090000
 #endif
 #ifdef F_sceCtrl_0001
 	IMPORT_FUNC	"sceCtrl",0x6A2774F3,sceCtrlSetSamplingCycle

--- a/src/ctrl/sceCtrl_driver.S
+++ b/src/ctrl/sceCtrl_driver.S
@@ -6,7 +6,7 @@
 // sceCtrl_driver_0000.o sceCtrl_driver_0001.o sceCtrl_driver_0002.o sceCtrl_driver_0003.o sceCtrl_driver_0004.o sceCtrl_driver_0005.o sceCtrl_driver_0006.o sceCtrl_driver_0007.o sceCtrl_driver_0008.o sceCtrl_driver_0009.o sceCtrl_driver_0010.o sceCtrl_driver_0011.o sceCtrl_driver_0012.o sceCtrl_driver_0013.o sceCtrl_driver_0014.o sceCtrl_driver_0015.o sceCtrl_driver_0016.o sceCtrl_driver_0017.o sceCtrl_driver_0018.o sceCtrl_driver_0019.o sceCtrl_driver_0020.o sceCtrl_driver_0021.o sceCtrl_driver_0022.o sceCtrl_driver_0023.o
 
 #ifdef F_sceCtrl_driver_0000
-	IMPORT_START	"sceCtrl_driver",0x00010000
+	IMPORT_START	"sceCtrl_driver",0x00090000
 #endif
 #ifdef F_sceCtrl_driver_0001
 	IMPORT_FUNC	"sceCtrl_driver",0x3E65A0EA,sceCtrlInit

--- a/src/display/sceDisplay.S
+++ b/src/display/sceDisplay.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceDisplay_0000
-	IMPORT_START	"sceDisplay",0x40010000
+	IMPORT_START	"sceDisplay",0x40090000
 #endif
 #ifdef F_sceDisplay_0001
 	IMPORT_FUNC	"sceDisplay",0x0E20F177,sceDisplaySetMode

--- a/src/display/sceDisplay_driver.S
+++ b/src/display/sceDisplay_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceDisplay_driver_0000
-	IMPORT_START	"sceDisplay_driver",0x00010000
+	IMPORT_START	"sceDisplay_driver",0x00090000
 #endif
 #ifdef F_sceDisplay_driver_0001
 	IMPORT_FUNC	"sceDisplay_driver",0x206276C2,sceDisplayInit

--- a/src/dmac/sceDmac.S
+++ b/src/dmac/sceDmac.S
@@ -1,7 +1,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceDmac_0000
-    IMPORT_START "sceDmac", 0x40010011
+    IMPORT_START "sceDmac", 0x40090000
 #endif
 #ifdef F_sceDmac_0001
     IMPORT_FUNC "sceDmac", 0x617F3FE6, sceDmacMemcpy

--- a/src/ge/sceGe_driver.S
+++ b/src/ge/sceGe_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceGe_driver_0000
-	IMPORT_START	"sceGe_driver",0x00010000
+	IMPORT_START	"sceGe_driver",0x00090000
 #endif
 #ifdef F_sceGe_driver_0001
 	IMPORT_FUNC	"sceGe_driver",0x71FCD1D6,sceGeInit

--- a/src/ge/sceGe_user.S
+++ b/src/ge/sceGe_user.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceGe_user_0000
-	IMPORT_START	"sceGe_user",0x40010000
+	IMPORT_START	"sceGe_user",0x40090000
 #endif
 #ifdef F_sceGe_user_0001
 	IMPORT_FUNC	"sceGe_user",0x1F6752AD,sceGeEdramGetSize

--- a/src/hprm/sceHprm.S
+++ b/src/hprm/sceHprm.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceHprm_0000
-	IMPORT_START	"sceHprm",0x40010000
+	IMPORT_START	"sceHprm",0x40090000
 #endif
 #ifdef F_sceHprm_0001
 	IMPORT_FUNC	"sceHprm",0xC7154136,sceHprmRegisterCallback

--- a/src/hprm/sceHprm_driver.S
+++ b/src/hprm/sceHprm_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceHprm_driver_0000
-	IMPORT_START	"sceHprm_driver",0x00010000
+	IMPORT_START	"sceHprm_driver",0x00090000
 #endif
 #ifdef F_sceHprm_driver_0001
 	IMPORT_FUNC	"sceHprm_driver",0x1C5BC5A0,sceHprmInit

--- a/src/kernel/ExceptionManagerForKernel.S
+++ b/src/kernel/ExceptionManagerForKernel.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_ExceptionManagerForKernel_0000
-	IMPORT_START	"ExceptionManagerForKernel",0x00010000
+	IMPORT_START	"ExceptionManagerForKernel",0x00090000
 #endif
 #ifdef F_ExceptionManagerForKernel_0001
 	IMPORT_FUNC	"ExceptionManagerForKernel",0x3FB264FC,sceKernelRegisterExceptionHandler

--- a/src/kernel/InterruptManagerForKernel.S
+++ b/src/kernel/InterruptManagerForKernel.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_InterruptManagerForKernel_0000
-	IMPORT_START	"InterruptManagerForKernel",0x00010000
+	IMPORT_START	"InterruptManagerForKernel",0x00090000
 #endif
 #ifdef F_InterruptManagerForKernel_0001
 	IMPORT_FUNC	"InterruptManagerForKernel",0x092968F4,sceKernelCpuSuspendIntr

--- a/src/kernel/IoFileMgrForKernel.S
+++ b/src/kernel/IoFileMgrForKernel.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_IoFileMgrForKernel_0000
-	IMPORT_START	"IoFileMgrForKernel",0x00010000
+	IMPORT_START	"IoFileMgrForKernel",0x00090000
 #endif
 #ifdef F_IoFileMgrForKernel_0001
 	IMPORT_FUNC	"IoFileMgrForKernel",0x3251EA56,sceIoPollAsync

--- a/src/kernel/KDebugForKernel.S
+++ b/src/kernel/KDebugForKernel.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_KDebugForKernel_0000
-	IMPORT_START	"KDebugForKernel",0x00010000
+	IMPORT_START	"KDebugForKernel",0x00090000
 #endif
 #ifdef F_KDebugForKernel_0001
 	IMPORT_FUNC	"KDebugForKernel",0xE7A3874D,sceKernelRegisterAssertHandler

--- a/src/kernel/LoadCoreForKernel.S
+++ b/src/kernel/LoadCoreForKernel.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_LoadCoreForKernel_0000
-	IMPORT_START	"LoadCoreForKernel",0x00010000
+	IMPORT_START	"LoadCoreForKernel",0x00090000
 #endif
 #ifdef F_LoadCoreForKernel_0001
 	IMPORT_FUNC	"LoadCoreForKernel",0xACE23476,sceKernelCheckPspConfig

--- a/src/kernel/LoadExecForKernel.S
+++ b/src/kernel/LoadExecForKernel.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_LoadExecForKernel_0000
-	IMPORT_START	"LoadExecForKernel",0x00010000
+	IMPORT_START	"LoadExecForKernel",0x00090000
 #endif
 #ifdef F_LoadExecForKernel_0001
 	IMPORT_FUNC	"LoadExecForKernel",0xBD2F1094,sceKernelLoadExec

--- a/src/kernel/ModuleMgrForKernel.S
+++ b/src/kernel/ModuleMgrForKernel.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_ModuleMgrForKernel_0000
-	IMPORT_START	"ModuleMgrForKernel",0x00010000
+	IMPORT_START	"ModuleMgrForKernel",0x00090000
 #endif
 #ifdef F_ModuleMgrForKernel_0001
 	IMPORT_FUNC	"ModuleMgrForKernel",0xABE84F8A,sceKernelLoadModuleBufferWithApitype

--- a/src/kernel/StdioForKernel.S
+++ b/src/kernel/StdioForKernel.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_StdioForKernel_0000
-	IMPORT_START	"StdioForKernel",0x00010000
+	IMPORT_START	"StdioForKernel",0x00090000
 #endif
 #ifdef F_StdioForKernel_0001
 	IMPORT_FUNC	"StdioForKernel",0x2CCF071A,fdprintf

--- a/src/kernel/SysMemForKernel.S
+++ b/src/kernel/SysMemForKernel.S
@@ -5,7 +5,7 @@
 // Build List
 
 #ifdef F_SysMemForKernel_0000
-	IMPORT_START	"SysMemForKernel",0x00010011
+	IMPORT_START	"SysMemForKernel",0x00010000
 #endif
 #ifdef F_SysMemForKernel_0001
 	IMPORT_FUNC	"SysMemForKernel",0x1C1FBFE7,sceKernelCreateHeap

--- a/src/kernel/SysTimerForKernel.S
+++ b/src/kernel/SysTimerForKernel.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_SysTimerForKernel_0000
-	IMPORT_START	"SysTimerForKernel",0x00010000
+	IMPORT_START	"SysTimerForKernel",0x00090000
 #endif
 #ifdef F_SysTimerForKernel_0001
 	IMPORT_FUNC	"SysTimerForKernel",0xC99073E3,sceSTimerAlloc

--- a/src/kernel/SysclibForKernel.S
+++ b/src/kernel/SysclibForKernel.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_SysclibForKernel_0000
-	IMPORT_START	"SysclibForKernel",0x00010000
+	IMPORT_START	"SysclibForKernel",0x00090000
 #endif
 #ifdef F_SysclibForKernel_0001
 	IMPORT_FUNC	"SysclibForKernel",0x476FD94A,strcat

--- a/src/kernel/ThreadManForKernel.S
+++ b/src/kernel/ThreadManForKernel.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_ThreadManForKernel_0000
-	IMPORT_START	"ThreadManForKernel",0x00010000
+	IMPORT_START	"ThreadManForKernel",0x00090000
 #endif
 #ifdef F_ThreadManForKernel_0001
 	IMPORT_FUNC	"ThreadManForKernel",0x0C106E53,sceKernelRegisterThreadEventHandler

--- a/src/kernel/sceAudioRouting_driver.S
+++ b/src/kernel/sceAudioRouting_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceAudioRouting_driver_0000
-	IMPORT_START	"sceAudioRouting_driver",0x00010000
+	IMPORT_START	"sceAudioRouting_driver",0x00090000
 #endif
 #ifdef F_sceAudioRouting_driver_0001
 	IMPORT_FUNC	"sceAudioRouting_driver",0x28235C56,sceAudioRoutingGetVolumeMode

--- a/src/kernel/sceIdStorage_driver.S
+++ b/src/kernel/sceIdStorage_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceIdStorage_driver_0000
-	IMPORT_START	"sceIdStorage_driver",0x00010000
+	IMPORT_START	"sceIdStorage_driver",0x00090000
 #endif
 #ifdef F_sceIdStorage_driver_0001
 	IMPORT_FUNC	"sceIdStorage_driver",0xAB129D20,sceIdStorageInit

--- a/src/kernel/sceImpose_driver.S
+++ b/src/kernel/sceImpose_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceImpose_driver_0000
-	IMPORT_START	"sceImpose_driver",0x00010011
+	IMPORT_START	"sceImpose_driver",0x00090000
 #endif
 #ifdef F_sceImpose_driver_0001
 	IMPORT_FUNC	"sceImpose_driver",0x0F341BE4,sceImposeGetHomePopup

--- a/src/kernel/sceSysEventForKernel.S
+++ b/src/kernel/sceSysEventForKernel.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceSysEventForKernel_0000
-	IMPORT_START	"sceSysEventForKernel",0x00010000
+	IMPORT_START	"sceSysEventForKernel",0x00090000
 #endif
 #ifdef F_sceSysEventForKernel_0001
 	IMPORT_FUNC	"sceSysEventForKernel",0xAEB300AE,sceKernelIsRegisterSysEventHandler

--- a/src/kernel/sceSyscon_driver.S
+++ b/src/kernel/sceSyscon_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceSyscon_driver_0000
-	IMPORT_START	"sceSyscon_driver",0x00010000
+	IMPORT_START	"sceSyscon_driver",0x00090000
 #endif
 #ifdef F_sceSyscon_driver_0001
 	IMPORT_FUNC	"sceSyscon_driver",0x0A771482,sceSysconInit

--- a/src/kernel/sceSysreg_driver.S
+++ b/src/kernel/sceSysreg_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceSysreg_driver_0000
-	IMPORT_START	"sceSysreg_driver",0x00010000
+	IMPORT_START	"sceSysreg_driver",0x00090000
 #endif
 #ifdef F_sceSysreg_driver_0001
 	IMPORT_FUNC	"sceSysreg_driver",0x9C863542,sceSysregInit

--- a/src/mp3/sceMp3.S
+++ b/src/mp3/sceMp3.S
@@ -6,7 +6,7 @@
 // sceMp3_0000.o sceMp3_0001.o sceMp3_0002.o sceMp3_0003.o sceMp3_0004.o sceMp3_0005.o sceMp3_0006.o sceMp3_0007.o sceMp3_0008.o sceMp3_0009.o sceMp3_0010.o sceMp3_0011.o sceMp3_0012.o sceMp3_0013.o sceMp3_0014.o sceMp3_0015.o sceMp3_0016.o sceMp3_0017.o sceMp3_0018.o sceMp3_0019.o 
 
 #ifdef F_sceMp3_0000
-	IMPORT_START	"sceMp3",0x00090011
+	IMPORT_START	"sceMp3",0x00090000
 #endif
 #ifdef F_sceMp3_0001
 	IMPORT_FUNC	"sceMp3",0x07EC321A,sceMp3ReserveMp3Handle

--- a/src/mpeg/sceMpegbase_driver.S
+++ b/src/mpeg/sceMpegbase_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceMpegbase_driver_0000
-	IMPORT_START	"sceMpegbase_driver",0x00010000
+	IMPORT_START	"sceMpegbase_driver",0x00090000
 #endif
 #ifdef F_sceMpegbase_driver_0001
 	IMPORT_FUNC	"sceMpegbase_driver",0xBE45C284,sceMpegBaseYCrCbCopyVme

--- a/src/nand/sceNand_driver.S
+++ b/src/nand/sceNand_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceNand_driver_0000
-	IMPORT_START	"sceNand_driver",0x00010000
+	IMPORT_START	"sceNand_driver",0x00090000
 #endif
 #ifdef F_sceNand_driver_0001
 	IMPORT_FUNC	"sceNand_driver",0xA513BB12,sceNandInit

--- a/src/net/sceHttp.S
+++ b/src/net/sceHttp.S
@@ -6,7 +6,7 @@
 // sceHttp_0000.o sceHttp_0001.o sceHttp_0002.o sceHttp_0003.o sceHttp_0004.o sceHttp_0005.o sceHttp_0006.o sceHttp_0007.o sceHttp_0008.o sceHttp_0009.o sceHttp_0010.o sceHttp_0011.o sceHttp_0012.o sceHttp_0013.o sceHttp_0014.o sceHttp_0015.o sceHttp_0016.o sceHttp_0017.o sceHttp_0018.o sceHttp_0019.o sceHttp_0020.o sceHttp_0021.o sceHttp_0022.o sceHttp_0023.o sceHttp_0024.o sceHttp_0025.o sceHttp_0026.o sceHttp_0027.o sceHttp_0028.o sceHttp_0029.o sceHttp_0030.o sceHttp_0031.o sceHttp_0032.o sceHttp_0033.o sceHttp_0034.o sceHttp_0035.o sceHttp_0036.o sceHttp_0037.o sceHttp_0038.o sceHttp_0039.o sceHttp_0040.o sceHttp_0041.o sceHttp_0042.o sceHttp_0043.o sceHttp_0044.o sceHttp_0045.o sceHttp_0046.o sceHttp_0047.o sceHttp_0048.o sceHttp_0049.o sceHttp_0050.o sceHttp_0051.o sceHttp_0052.o sceHttp_0053.o sceHttp_0054.o sceHttp_0055.o sceHttp_0056.o sceHttp_0057.o sceHttp_0058.o sceHttp_0059.o sceHttp_0060.o sceHttp_0061.o sceHttp_0062.o sceHttp_0063.o sceHttp_0064.o sceHttp_0065.o sceHttp_0066.o sceHttp_0067.o sceHttp_0068.o sceHttp_0069.o sceHttp_0070.o sceHttp_0071.o sceHttp_0072.o sceHttp_0073.o sceHttp_0074.o sceHttp_0075.o sceHttp_0076.o sceHttp_0077.o sceHttp_0078.o sceHttp_0079.o sceHttp_0080.o sceHttp_0081.o sceHttp_0082.o sceHttp_0083.o
 
 #ifdef F_sceHttp_0000
-	IMPORT_START	"sceHttp",0x00090011
+	IMPORT_START	"sceHttp",0x00090000
 #endif
 #ifdef F_sceHttp_0001
 	IMPORT_FUNC	"sceHttp",0x0282A3BD,sceHttpGetContentLength

--- a/src/net/sceSsl.S
+++ b/src/net/sceSsl.S
@@ -6,7 +6,7 @@
 // sceSsl_0000.o sceSsl_0001.o sceSsl_0002.o sceSsl_0003.o sceSsl_0004.o sceSsl_0005.o sceSsl_0006.o sceSsl_0007.o sceSsl_0008.o sceSsl_0009.o sceSsl_0010.o sceSsl_0011.o 
 
 #ifdef F_sceSsl_0000
-	IMPORT_START	"sceSsl",0x00090011
+	IMPORT_START	"sceSsl",0x00090000
 #endif
 #ifdef F_sceSsl_0001
 	IMPORT_FUNC	"sceSsl",0x058D21C0,sceSslGetNameEntryCount

--- a/src/openpsid/sceOpenPSID.S
+++ b/src/openpsid/sceOpenPSID.S
@@ -6,7 +6,7 @@
 // sceOpenPSID_0000.o sceOpenPSID_0001.o 
 
 #ifdef F_sceOpenPSID_0000
-	IMPORT_START	"sceOpenPSID",0x40010011
+	IMPORT_START	"sceOpenPSID",0x40090000
 #endif
 #ifdef F_sceOpenPSID_0001
 	IMPORT_FUNC	"sceOpenPSID",0xC69BEBCE,sceOpenPSIDGetOpenPSID

--- a/src/power/scePower.S
+++ b/src/power/scePower.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_scePower_0000
-	IMPORT_START	"scePower",0x40010000
+	IMPORT_START	"scePower",0x40090000
 #endif
 #ifdef F_scePower_0001
 	IMPORT_FUNC	"scePower",0x2B51FE2F,scePowerGetWlanActivity

--- a/src/power/scePower_driver.S
+++ b/src/power/scePower_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_scePower_driver_0000
-	IMPORT_START	"scePower_driver",0x00010000
+	IMPORT_START	"scePower_driver",0x00090000
 #endif
 #ifdef F_scePower_driver_0001
 	IMPORT_FUNC	"scePower_driver",0x9CE06934,scePowerInit

--- a/src/rtc/sceRtc.S
+++ b/src/rtc/sceRtc.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceRtc_0000
-	IMPORT_START	"sceRtc",0x40010000
+	IMPORT_START	"sceRtc",0x40090000
 #endif
 #ifdef F_sceRtc_0001
 	IMPORT_FUNC	"sceRtc",0xC41C2853,sceRtcGetTickResolution

--- a/src/rtc/sceRtc_driver.S
+++ b/src/rtc/sceRtc_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceRtc_driver_0000
-	IMPORT_START	"sceRtc_driver",0x00010000
+	IMPORT_START	"sceRtc_driver",0x00090000
 #endif
 #ifdef F_sceRtc_driver_0001
 	IMPORT_FUNC	"sceRtc_driver",0xC41C2853,sceRtcGetTickResolution

--- a/src/sascore/sceSasCore.S
+++ b/src/sascore/sceSasCore.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceSasCore_0000
-	IMPORT_START	"sceSasCore",0x40090011
+	IMPORT_START	"sceSasCore",0x40090000
 #endif
 #ifdef F___sceSasInit_0001
 	IMPORT_FUNC	"sceSasCore",0x42778A9F,__sceSasInit

--- a/src/sircs/sceSircs.S
+++ b/src/sircs/sceSircs.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceSircs_0000
-	IMPORT_START	"sceSircs",0x40010000
+	IMPORT_START	"sceSircs",0x40090000
 #endif
 #ifdef F_sceSircs_0001
 	IMPORT_FUNC	"sceSircs",0x71EEF62D,sceSircsSend

--- a/src/umd/sceUmdUser.S
+++ b/src/umd/sceUmdUser.S
@@ -6,7 +6,7 @@
 // sceUmdUser_0000.o sceUmdUser_0001.o sceUmdUser_0002.o sceUmdUser_0003.o sceUmdUser_0004.o sceUmdUser_0005.o sceUmdUser_0006.o sceUmdUser_0007.o sceUmdUser_0008.o sceUmdUser_0009.o sceUmdUser_0010.o sceUmdUser_0011.o sceUmdUser_0012.o sceUmdUser_0013.o sceUmdUser_0014.o 
 
 #ifdef F_sceUmdUser_0000
-	IMPORT_START	"sceUmdUser",0x40010011
+	IMPORT_START	"sceUmdUser",0x40090000
 #endif
 #ifdef F_sceUmdUser_0001
 	IMPORT_FUNC	"sceUmdUser",0x20628E6F,sceUmdGetErrorStat

--- a/src/usb/sceUsb.S
+++ b/src/usb/sceUsb.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceUsb_0000
-	IMPORT_START	"sceUsb",0x40010000
+	IMPORT_START	"sceUsb",0x40090000
 #endif
 #ifdef F_sceUsb_0001
 	IMPORT_FUNC	"sceUsb",0xAE5DE6AF,sceUsbStart

--- a/src/usb/sceUsbBus_driver.S
+++ b/src/usb/sceUsbBus_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceUsbBus_driver_0000
-	IMPORT_START	"sceUsbBus_driver",0x00010000
+	IMPORT_START	"sceUsbBus_driver",0x00090000
 #endif
 #ifdef F_sceUsbBus_driver_0001
 	IMPORT_FUNC	"sceUsbBus_driver",0xC21645A4,sceUsbGetState

--- a/src/usb/sceUsb_driver.S
+++ b/src/usb/sceUsb_driver.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceUsb_driver_0000
-	IMPORT_START	"sceUsb_driver",0x00010000
+	IMPORT_START	"sceUsb_driver",0x00090000
 #endif
 #ifdef F_sceUsb_driver_0001
 	IMPORT_FUNC	"sceUsb_driver",0xAE5DE6AF,sceUsbStart

--- a/src/user/InterruptManager.S
+++ b/src/user/InterruptManager.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_InterruptManager_0000
-	IMPORT_START	"InterruptManager",0x40000000
+	IMPORT_START	"InterruptManager",0x40080000
 #endif
 #ifdef F_InterruptManager_0001
 	IMPORT_FUNC	"InterruptManager",0xCA04A2B9,sceKernelRegisterSubIntrHandler

--- a/src/user/IoFileMgrForUser.S
+++ b/src/user/IoFileMgrForUser.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_IoFileMgrForUser_0000
-	IMPORT_START	"IoFileMgrForUser",0x40010000
+	IMPORT_START	"IoFileMgrForUser",0x40090000
 #endif
 #ifdef F_IoFileMgrForUser_0001
 	IMPORT_FUNC	"IoFileMgrForUser",0x3251EA56,sceIoPollAsync

--- a/src/user/Kernel_Library.S
+++ b/src/user/Kernel_Library.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_Kernel_Library_0000
-	IMPORT_START	"Kernel_Library",0x00010000
+	IMPORT_START	"Kernel_Library",0x00090000
 #endif
 #ifdef F_Kernel_Library_0001
 	IMPORT_FUNC	"Kernel_Library",0x092968F4,sceKernelCpuSuspendIntr

--- a/src/user/LoadExecForUser.S
+++ b/src/user/LoadExecForUser.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_LoadExecForUser_0000
-	IMPORT_START	"LoadExecForUser",0x40010000
+	IMPORT_START	"LoadExecForUser",0x40090000
 #endif
 #ifdef F_LoadExecForUser_0001
 	IMPORT_FUNC	"LoadExecForUser",0xBD2F1094,sceKernelLoadExec

--- a/src/user/ModuleMgrForUser.S
+++ b/src/user/ModuleMgrForUser.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_ModuleMgrForUser_0000
-	IMPORT_START	"ModuleMgrForUser",0x40010000
+	IMPORT_START	"ModuleMgrForUser",0x40090000
 #endif
 #ifdef F_ModuleMgrForUser_0001
 	IMPORT_FUNC	"ModuleMgrForUser",0xB7F46618,sceKernelLoadModuleByID

--- a/src/user/StdioForUser.S
+++ b/src/user/StdioForUser.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_StdioForUser_0000
-	IMPORT_START	"StdioForUser",0x40010000
+	IMPORT_START	"StdioForUser",0x40090000
 #endif
 #ifdef F_StdioForUser_0001
 	IMPORT_FUNC	"StdioForUser",0x3054D478,sceKernelStdioRead

--- a/src/user/SysMemUserForUser.S
+++ b/src/user/SysMemUserForUser.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_SysMemUserForUser_0000
-	IMPORT_START	"SysMemUserForUser",0x40000000
+	IMPORT_START	"SysMemUserForUser",0x40080000
 #endif
 #ifdef F_SysMemUserForUser_0001
 	IMPORT_FUNC	"SysMemUserForUser",0xA291F107,sceKernelMaxFreeMemSize

--- a/src/user/ThreadManForUser.S
+++ b/src/user/ThreadManForUser.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_ThreadManForUser_0000
-	IMPORT_START	"ThreadManForUser",0x40010000
+	IMPORT_START	"ThreadManForUser",0x40090000
 #endif
 #ifdef F_ThreadManForUser_0001
 	IMPORT_FUNC	"ThreadManForUser",0x6E9EA350,_sceKernelReturnFromCallback

--- a/src/user/UtilsForUser.S
+++ b/src/user/UtilsForUser.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_UtilsForUser_0000
-	IMPORT_START	"UtilsForUser",0x40010000
+	IMPORT_START	"UtilsForUser",0x40090000
 #endif
 #ifdef F_UtilsForUser_0001
 	IMPORT_FUNC	"UtilsForUser",0xBFA98062,sceKernelDcacheInvalidateRange

--- a/src/user/sceAudioRouting.S
+++ b/src/user/sceAudioRouting.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceAudioRouting_0000
-	IMPORT_START	"sceAudioRouting",0x40010000
+	IMPORT_START	"sceAudioRouting",0x40090000
 #endif
 #ifdef F_sceAudioRouting_0001
 	IMPORT_FUNC	"sceAudioRouting",0x28235C56,sceAudioRoutingGetVolumeMode

--- a/src/user/sceImpose.S
+++ b/src/user/sceImpose.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceImpose_0000
-	IMPORT_START	"sceImpose",0x40010011
+	IMPORT_START	"sceImpose",0x40090000
 #endif
 #ifdef F_sceImpose_0001
 	IMPORT_FUNC	"sceImpose",0x0F341BE4,sceImposeGetHomePopup

--- a/src/user/sceSuspendForUser.S
+++ b/src/user/sceSuspendForUser.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceSuspendForUser_0000
-	IMPORT_START	"sceSuspendForUser",0x40000000
+	IMPORT_START	"sceSuspendForUser",0x40080000
 #endif
 #ifdef F_sceSuspendForUser_0001
 	IMPORT_FUNC	"sceSuspendForUser",0xEADB1BD7,sceKernelPowerLock

--- a/src/utility/sceUtility.S
+++ b/src/utility/sceUtility.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceUtility_0000
-	IMPORT_START	"sceUtility",0x40010000
+	IMPORT_START	"sceUtility",0x40090000
 #endif
 #ifdef F_sceUtility_0001
 	IMPORT_FUNC	"sceUtility",0xC492F751,sceUtilityGameSharingInitStart

--- a/src/utility/sceUtility_netparam_internal.S
+++ b/src/utility/sceUtility_netparam_internal.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceUtility_netparam_internal_0000
-	IMPORT_START	"sceUtility_netparam_internal",0x40010000
+	IMPORT_START	"sceUtility_netparam_internal",0x40090000
 #endif
 #ifdef F_sceUtility_netparam_internal_0001
 	IMPORT_FUNC	"sceUtility_netparam_internal",0x072DEBF2,sceUtilityCreateNetParam

--- a/src/video/sceVideocodec.S
+++ b/src/video/sceVideocodec.S
@@ -6,7 +6,7 @@
 // sceVideocodec_0000.o sceVideocodec_0001.o sceVideocodec_0002.o sceVideocodec_0003.o sceVideocodec_0004.o sceVideocodec_0005.o sceVideocodec_0006.o sceVideocodec_0007.o sceVideocodec_0008.o sceVideocodec_0009.o sceVideocodec_0010.o sceVideocodec_0011.o 
 
 #ifdef F_sceVideocodec_0000
-	IMPORT_START	"sceVideocodec",0x40010011
+	IMPORT_START	"sceVideocodec",0x40090000
 #endif
 #ifdef F_sceVideocodec_0001
 	IMPORT_FUNC	"sceVideocodec",0x17099F0A,sceVideocodecInit

--- a/src/vsh/sceChnnlsv.S
+++ b/src/vsh/sceChnnlsv.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceChnnlsv_0000
-	IMPORT_START	"sceChnnlsv",0x40010000
+	IMPORT_START	"sceChnnlsv",0x40090000
 #endif
 #ifdef F_sceChnnlsv_0001
 	IMPORT_FUNC	"sceChnnlsv",0xE7833020,sceSdSetIndex

--- a/src/vsh/scePaf.S
+++ b/src/vsh/scePaf.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_scePaf_0000
-	IMPORT_START	"scePaf",0x00010000
+	IMPORT_START	"scePaf",0x00090000
 #endif
 #ifdef F_scePaf_0001
 	IMPORT_FUNC	"scePaf",0xC9831AFF,scePaf_C9831AFF

--- a/src/vsh/sceVshBridge.S
+++ b/src/vsh/sceVshBridge.S
@@ -6,7 +6,7 @@
 // sceVshBridge_0000.o sceVshBridge_0001.o sceVshBridge_0002.o sceVshBridge_0003.o sceVshBridge_0004.o sceVshBridge_0005.o sceVshBridge_0006.o sceVshBridge_0007.o sceVshBridge_0008.o sceVshBridge_0009.o sceVshBridge_0010.o sceVshBridge_0011.o sceVshBridge_0012.o sceVshBridge_0013.o sceVshBridge_0014.o sceVshBridge_0015.o sceVshBridge_0016.o sceVshBridge_0017.o sceVshBridge_0018.o sceVshBridge_0019.o sceVshBridge_0020.o sceVshBridge_0021.o sceVshBridge_0022.o sceVshBridge_0023.o sceVshBridge_0024.o sceVshBridge_0025.o sceVshBridge_0026.o sceVshBridge_0027.o sceVshBridge_0028.o sceVshBridge_0029.o sceVshBridge_0030.o sceVshBridge_0031.o sceVshBridge_0032.o sceVshBridge_0033.o sceVshBridge_0034.o sceVshBridge_0035.o sceVshBridge_0036.o sceVshBridge_0037.o sceVshBridge_0038.o sceVshBridge_0039.o sceVshBridge_0040.o sceVshBridge_0041.o sceVshBridge_0042.o sceVshBridge_0043.o sceVshBridge_0044.o sceVshBridge_0045.o sceVshBridge_0046.o sceVshBridge_0047.o sceVshBridge_0048.o sceVshBridge_0049.o sceVshBridge_0050.o sceVshBridge_0051.o sceVshBridge_0052.o sceVshBridge_0053.o sceVshBridge_0054.o sceVshBridge_0055.o sceVshBridge_0056.o sceVshBridge_0057.o sceVshBridge_0058.o sceVshBridge_0059.o sceVshBridge_0060.o sceVshBridge_0061.o sceVshBridge_0062.o sceVshBridge_0063.o sceVshBridge_0064.o sceVshBridge_0065.o 
 
 #ifdef F_sceVshBridge_0000
-	IMPORT_START	"sceVshBridge",0x40010000
+	IMPORT_START	"sceVshBridge",0x40090000
 #endif
 #ifdef F_sceVshBridge_0001
 	IMPORT_FUNC	"sceVshBridge",0xA5628F0D,vshKernelLoadModuleVSH

--- a/src/wlan/sceWlanDrv.S
+++ b/src/wlan/sceWlanDrv.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceWlanDrv_0000
-	IMPORT_START	"sceWlanDrv",0x40010000
+	IMPORT_START	"sceWlanDrv",0x40090000
 #endif
 #ifdef F_sceWlanDrv_0001
 	IMPORT_FUNC	"sceWlanDrv",0x93440B11,sceWlanDevIsPowerOn

--- a/src/wlan/sceWlanDrv_lib.S
+++ b/src/wlan/sceWlanDrv_lib.S
@@ -3,7 +3,7 @@
 #include "pspimport.s"
 
 #ifdef F_sceWlanDrv_lib_0000
-	IMPORT_START	"sceWlanDrv_lib",0x40010000
+	IMPORT_START	"sceWlanDrv_lib",0x40090000
 #endif
 #ifdef F_sceWlanDrv_lib_0001
 	IMPORT_FUNC	"sceWlanDrv_lib",0x482CAE9A,sceWlanDevAttach


### PR DESCRIPTION
Make all stubs weak. This makes modules not fail to load when a linked lib was not loaded yet.

This is benefitial mostly for plugins, as they are often loaded before all system modules were started. And CFW have API that allows to inject a module to be loaded as early as the second module the system loads; in this edge case, all modules but sysmem libraries ideally should be weak.

I also noticed that some stubs were with the version part as `0011` which is the system module version used on `FW>=6.60` on some modules, this will cause any module linking to them to fail loading on firmware version `<6.60` as the system checks the stubs version on load if the library module was already loaded (if the imports are below or equal to the loaded library version, the module fails to load). On the cases of library modules allowed to be loaded multiple instaces of the module, at least one loaded version must match the imported stub version. I did not test the case of a weak imported with version bigger than the version that will be loaded after, but my best guess is that some error will occur in this case as well. To avoid this, I put then all to zero on the SDK stubs.

